### PR TITLE
Add Entra ID MFA example

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,3 +312,25 @@ For production, consider migrating from SQLite to PostgreSQL:
 For issues and questions:
 - GitHub Issues: [repository-url]/issues
 - Documentation: [documentation-url]
+## Entra ID MFA Integration
+
+### Azure registration
+1. Register a **SPA** app in Entra and note the **Application (client) ID**.
+   - Enable the *Authorization code* and *Implicit* grants for ID and access tokens.
+   - Set the redirect URI to `http://localhost:5173`.
+2. Register an **API** app and expose an API scope. Note the **Application ID URI**.
+3. In the SPA's **API permissions**, add access to the API scope.
+
+### Conditional Access
+1. Open **Entra ID > Protection > Conditional Access**.
+2. Create a **New policy** > **Cloud apps** > select your SPA's application ID.
+3. Under **Grant**, select **Require multi-factor authentication** and enable the policy.
+   <!-- MFA enforcement happens here, not in code -->
+
+### Local development
+```bash
+cd spa && npm i && npm run dev      # start React + Vite SPA
+cd ../api && npm i && node index.js # start Express API
+```
+
+The default admin credentials remain `admin/admin` for backwards compatibility.

--- a/api/.env
+++ b/api/.env
@@ -1,0 +1,3 @@
+CLIENT_ID=YOUR_CLIENT_ID
+TENANT_ID=YOUR_TENANT_ID
+AUTHORITY=https://login.microsoftonline.com

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,22 @@
+require('dotenv').config()
+const express = require('express')
+const { msalExpressMiddleware } = require('microsoft-identity-express')
+
+const app = express()
+
+const msalConfig = {
+  auth: {
+    clientId: process.env.CLIENT_ID,
+    authority: `${process.env.AUTHORITY}/${process.env.TENANT_ID}`,
+    // clientSecret optional for SPA tokens
+  }
+}
+
+app.use(msalExpressMiddleware(msalConfig)) // MFA enforced via Conditional Access policies in Entra
+
+app.get('/me', (req, res) => {
+  const c = req.authInfo || {}
+  res.json({ preferred_username: c.preferred_username, tid: c.tid })
+})
+
+app.listen(3001, () => console.log('API listening on 3001'))

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "chatbot-api",
+  "private": true,
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "dotenv": "^16",
+    "express": "^4",
+    "microsoft-identity-express": "^1"
+  }
+}

--- a/spa/.env
+++ b/spa/.env
@@ -1,0 +1,5 @@
+VITE_CLIENT_ID=YOUR_CLIENT_ID
+VITE_TENANT_ID=YOUR_TENANT_ID
+VITE_AUTHORITY=https://login.microsoftonline.com
+VITE_REDIRECT_URI=http://localhost:5173
+API_BASE=http://localhost:3001

--- a/spa/index.html
+++ b/spa/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chatbot</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/spa/package.json
+++ b/spa/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "chatbot-spa",
+  "private": true,
+  "scripts": {
+    "dev": "vite"
+  },
+  "dependencies": {
+    "@azure/msal-browser": "^3",
+    "@azure/msal-react": "^2",
+    "react": "^18",
+    "react-dom": "^18"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4",
+    "vite": "^4"
+  }
+}

--- a/spa/src/App.jsx
+++ b/spa/src/App.jsx
@@ -1,0 +1,30 @@
+import { useMsal, useIsAuthenticated } from '@azure/msal-react'
+import { loginRequest } from './authConfig'
+
+export default function App() {
+  const { instance, accounts } = useMsal()
+  const isAuthenticated = useIsAuthenticated()
+
+  const login = () => instance.loginRedirect(loginRequest)
+
+  const callMe = async () => {
+    const account = accounts[0]
+    const result = await instance.acquireTokenSilent({ ...loginRequest, account })
+    const res = await fetch(`${import.meta.env.API_BASE}/me`, {
+      headers: { Authorization: `Bearer ${result.idToken}` }
+    })
+    alert(JSON.stringify(await res.json()))
+  }
+
+  return (
+    <div style={{ padding: 40 }}>
+      {isAuthenticated ? (
+        <>
+          <button onClick={callMe}>Call API</button>
+        </>
+      ) : (
+        <button onClick={login}>Login</button>
+      )}
+    </div>
+  )
+}

--- a/spa/src/authConfig.js
+++ b/spa/src/authConfig.js
@@ -1,0 +1,4 @@
+export const loginRequest = {
+  scopes: ['openid', 'profile']
+  // MFA can be enforced in Azure Conditional Access for these scopes
+}

--- a/spa/src/main.jsx
+++ b/spa/src/main.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import { PublicClientApplication } from '@azure/msal-browser'
+import { MsalProvider } from '@azure/msal-react'
+
+const msalInstance = new PublicClientApplication({
+  auth: {
+    clientId: import.meta.env.VITE_CLIENT_ID,
+    authority: `${import.meta.env.VITE_AUTHORITY}/${import.meta.env.VITE_TENANT_ID}`,
+    redirectUri: import.meta.env.VITE_REDIRECT_URI
+  }
+})
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <MsalProvider instance={msalInstance}>
+      <App />
+    </MsalProvider>
+  </React.StrictMode>
+)

--- a/spa/vite.config.js
+++ b/spa/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 5173 }
+})


### PR DESCRIPTION
## Summary
- document how to register SPA/API and enable MFA via Conditional Access
- add a React + Vite SPA using MSAL and call the `/me` API
- add an Express API validating ID tokens via `microsoft-identity-express`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684e0035fea0832e868ab551ac62344c