### PR TITLE
Fix bcrypt version for passlib compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,9 @@ python-multipart>=0.0.6
 
 # Authentication
 python-jose[cryptography]>=3.3.0
+# Pin bcrypt below 4.x due to incompatibility with passlib 1.7
 passlib[bcrypt]>=1.7.4
+bcrypt<4
 
 # RAG and LLM
 langchain>=0.1.0


### PR DESCRIPTION
## Summary
- pin bcrypt below v4 to avoid passlib warnings about missing `__about__`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e2a2f2300832e834ec1979a407865