### PR TITLE
Fix admin.html embed script parsing

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -1558,7 +1558,7 @@
         }
 
         function getEmbedCode(tenant, agent) {
-            const embedCode = `<script src="${API_BASE}/widget.js?tenant=${tenant}&agent=${agent}"></script>`;
+            const embedCode = `<script src="${API_BASE}/widget.js?tenant=${tenant}&agent=${agent}"><\/script>`;
             
             const modal = document.createElement('div');
             modal.className = 'modal';


### PR DESCRIPTION
## Summary
- escape `</script>` in the `getEmbedCode` function

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684e117fd8ac832eabe52121e4b78f01