### PR TITLE
Restrict admin capabilities and reset forms

### DIFF
--- a/routers/config_routes.py
+++ b/routers/config_routes.py
@@ -116,6 +116,13 @@ async def update_config_enhanced(
 async def list_tenants(current_user: User = Depends(get_admin_user)):
     """List all tenants and their agents"""
     tenants = []
+    if current_user.role != "system_admin":
+        tenant_dir = BASE_CONFIG_DIR / current_user.tenant
+        if tenant_dir.is_dir():
+            agents = [f.stem for f in tenant_dir.iterdir() if f.is_file() and f.suffix == ".json"]
+            tenants.append({"tenant": current_user.tenant, "agents": agents})
+        return tenants
+
     for tenant_dir in BASE_CONFIG_DIR.iterdir():
         if tenant_dir.is_dir():
             agents = []

--- a/static/admin.html
+++ b/static/admin.html
@@ -856,6 +856,7 @@
             // Create buttons
             document.getElementById('createTenantBtn').addEventListener('click', () => showModal('createTenantModal'));
             document.getElementById('createUserBtn').addEventListener('click', () => {
+                document.getElementById('createUserForm').reset();
                 loadTenantsForUser();
                 showModal('createUserModal');
             });
@@ -955,6 +956,9 @@
         }
 
         function showLoginPage() {
+            document.getElementById('loginForm').reset();
+            const error = document.getElementById('loginError');
+            if (error) error.classList.add('hidden');
             document.getElementById('loginPage').classList.remove('hidden');
             document.getElementById('mainInterface').classList.add('hidden');
         }
@@ -1384,12 +1388,17 @@
                 if (response.ok) {
                     const tenants = await response.json();
                     const select = document.getElementById('newUserTenant');
-                    
-                    // Clear existing options except "All Tenants"
-                    while (select.children.length > 1) {
-                        select.removeChild(select.lastChild);
+
+                    // Clear existing options
+                    select.innerHTML = '';
+
+                    if (currentUser.role === 'system_admin') {
+                        const optAll = document.createElement('option');
+                        optAll.value = '*';
+                        optAll.textContent = 'All Tenants (Admin)';
+                        select.appendChild(optAll);
                     }
-                    
+
                     tenants.forEach(tenant => {
                         const option = document.createElement('option');
                         option.value = tenant.tenant;


### PR DESCRIPTION
## Summary
- clear login screen and new user form every time they're opened
- show tenant options according to user role
- restrict admins to only create regular users
- limit `/users` and `/tenants` views to the current tenant for admins

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f9a93d9a8832ea0d37d8adbd5891a