### PR TITLE
Fix base data paths

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -13,7 +13,12 @@ from jose import JWTError, jwt
 from passlib.context import CryptContext
 
 from .models import User, UserCreate, TokenData
-from .config import SECRET_KEY, ALGORITHM, ACCESS_TOKEN_EXPIRE_MINUTES
+from .config import (
+    SECRET_KEY,
+    ALGORITHM,
+    ACCESS_TOKEN_EXPIRE_MINUTES,
+    BASE_DIR,
+)
 
 # Override with environment variable if available
 SECRET_KEY = os.getenv("JWT_SECRET_KEY", SECRET_KEY)
@@ -25,7 +30,7 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
 def get_users_db():
     """Get the users database"""
-    users_file = Path("users.json")
+    users_file = BASE_DIR / "users.json"
     if not users_file.exists():
         # Create default admin user if no users file exists
         default_admin = {
@@ -45,7 +50,7 @@ def get_users_db():
 
 def save_users_db(users_data):
     """Save the users database"""
-    users_file = Path("users.json")
+    users_file = BASE_DIR / "users.json"
     users_file.write_text(json.dumps(users_data, indent=2))
 
 

--- a/config.py
+++ b/config.py
@@ -2,18 +2,22 @@
 config.py - Configuration management for the RAG chatbot
 """
 import json
+import os
 from pathlib import Path
 from typing import Dict, Any
 
+# Determine base data directory
+BASE_DIR = Path(os.getenv("RAG_CHATBOT_HOME", Path.cwd()))
+
 # Base configuration
-BASE_CONFIG_DIR = Path("configs")
-BASE_CONFIG_DIR.mkdir(exist_ok=True)
-BASE_STORE_DIR = Path("vector_store")
+BASE_CONFIG_DIR = BASE_DIR / "configs"
+BASE_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+BASE_STORE_DIR = BASE_DIR / "vector_store"
 DEFAULT_TENANT = "public"
 DEFAULT_AGENT = "default"
 
 # Database path
-DB_PATH = Path("chat_logs.db")
+DB_PATH = BASE_DIR / "chat_logs.db"
 
 # JWT Configuration
 SECRET_KEY = "dev_secret_key_change_in_production"  # Override with env var


### PR DESCRIPTION
## Summary
- allow overriding base data directory with env `RAG_CHATBOT_HOME`
- use this path when loading/saving `users.json`

## Testing
- `python -m py_compile config.py auth.py`

------
https://chatgpt.com/codex/tasks/task_e_684fa03b8824832e894f80e65d47c42a