### PR TITLE
Fix admin role for default user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+venv/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ python -m rag_chatbot.cli serve --reload
 
 - **Username**: admin
 - **Password**: admin
+- Role: `system_admin` (full access)
 
 ⚠️ **Important**: Change the default password immediately after first login!
 

--- a/users.json
+++ b/users.json
@@ -2,7 +2,8 @@
   "admin": {
     "username": "admin",
     "tenant": "*",
-    "role": "admin",
+    "role": "system_admin",
+    "agents": [],
     "hashed_password": "$2b$12$QJJmC4jT9RriTGXB2J73S./R0DHYlFrjGt2fTObeuhFDGKwaPlOuy",
     "disabled": false
   }


### PR DESCRIPTION
## Summary
- correct the default admin's role to `system_admin`
- document the admin role in README
- add `.gitignore`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fa216f9e8832e97e9aa20d335b28c