### PR TITLE
Add vector store size reporting

### DIFF
--- a/routers/config_routes.py
+++ b/routers/config_routes.py
@@ -14,6 +14,7 @@ from ..config import (
     save_config,
     store_path
 )
+from ..vectorstore import get_vector_store_size
 
 router = APIRouter(tags=["configuration"])
 
@@ -220,6 +221,8 @@ async def get_agent_status(
     
     config = load_config(tenant, agent)
     vector_store_exists = store_path(tenant, agent).exists()
+    size_bytes = get_vector_store_size(tenant, agent)
+    storage_gb = size_bytes / (1024 ** 3)
     
     # Get usage statistics from database
     from ..database import get_chat_stats
@@ -242,6 +245,7 @@ async def get_agent_status(
         "agent": agent,
         "config": config,
         "vector_store_ready": vector_store_exists,
+        "storage_gb": storage_gb,
         "statistics": {
             "total_chats": total_chats,
             "unique_sessions": unique_sessions,

--- a/static/admin.html
+++ b/static/admin.html
@@ -1190,11 +1190,15 @@
                         <div class="stat-number">${data.feedback?.average?.toFixed(1) || 'N/A'}</div>
                         <div class="stat-label">Avg Feedback</div>
                     </div>
-                    <div class="stat-card">
-                        <div class="stat-number">${data.performance?.mean?.toFixed(2) || 'N/A'}s</div>
-                        <div class="stat-label">Avg Response Time</div>
-                    </div>
+                <div class="stat-card">
+                    <div class="stat-number">${data.performance?.mean?.toFixed(2) || 'N/A'}s</div>
+                    <div class="stat-label">Avg Response Time</div>
                 </div>
+                <div class="stat-card">
+                    <div class="stat-number">${data.storage_gb?.toFixed(2) || '0'}</div>
+                    <div class="stat-label">Vector Store (GB)</div>
+                </div>
+            </div>
             `;
         }
 

--- a/vectorstore.py
+++ b/vectorstore.py
@@ -3,6 +3,7 @@ vectorstore.py - Vector store operations and RAG functionality
 """
 from typing import Dict, List, Tuple
 from pathlib import Path
+import os
 
 from fastapi import HTTPException
 
@@ -119,3 +120,19 @@ def chunk_text(text: str) -> List[str]:
     """Chunk text into smaller pieces for vectorization"""
     _require_deps()
     return TEXT_SPLITTER.split_text(text)
+
+
+def get_vector_store_size(tenant: str, agent: str) -> int:
+    """Return the size in bytes of the vector store for a tenant/agent."""
+    path = store_path(tenant, agent)
+    if not path.exists():
+        return 0
+
+    if path.is_file():
+        return os.path.getsize(path)
+
+    size = 0
+    for p in path.rglob("*"):
+        if p.is_file():
+            size += os.path.getsize(p)
+    return size


### PR DESCRIPTION
## Summary
- add helper to compute vector store size
- expose storage usage in `/agent-status`
- show vector store size in Admin analytics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850e4168ba8832e96b170f2eec8659f