### PR TITLE
Add background watcher for automated ingestion

### DIFF
--- a/embedding.py
+++ b/embedding.py
@@ -1,0 +1,33 @@
+"""Embedding provider utilities"""
+from typing import Optional
+
+
+def get_embedding_model(provider: str = "openai", model: Optional[str] = None):
+    """Return a LangChain embedding model for the given provider."""
+    provider = provider.lower()
+    if provider == "openai":
+        try:
+            from langchain_openai import OpenAIEmbeddings
+        except ModuleNotFoundError as e:  # pragma: no cover - optional deps
+            raise ImportError("langchain_openai package not installed") from e
+        return OpenAIEmbeddings(model=model or "text-embedding-3-small")
+    elif provider == "anthropic":
+        try:
+            from langchain_community.embeddings import AnthropicEmbeddings
+        except ModuleNotFoundError as e:  # pragma: no cover - optional deps
+            raise ImportError("Anthropic dependencies not installed") from e
+        return AnthropicEmbeddings(model=model or "claude-3-embedding-001")
+    elif provider in {"vertexai", "google"}:
+        try:
+            from langchain_google_vertexai import VertexAIEmbeddings
+        except ModuleNotFoundError as e:  # pragma: no cover - optional deps
+            raise ImportError("google-cloud-aiplatform package not installed") from e
+        return VertexAIEmbeddings(model_name=model or "textembedding-gecko@001")
+    elif provider == "local":
+        try:
+            from langchain_community.embeddings import HuggingFaceEmbeddings
+        except ModuleNotFoundError as e:  # pragma: no cover - optional deps
+            raise ImportError("sentence-transformers package not installed") from e
+        return HuggingFaceEmbeddings(model_name=model or "sentence-transformers/all-MiniLM-L6-v2")
+    else:
+        raise ValueError(f"Unknown embedding provider: {provider}")

--- a/ingestion.py
+++ b/ingestion.py
@@ -20,7 +20,9 @@ def ingest(
     sitemap: Optional[str] = None,
     drive: Optional[str] = None,
     files: Optional[List[Path]] = None,
-    console: Optional[Console] = None
+    console: Optional[Console] = None,
+    embedding_provider: str = "openai",
+    embedding_model: str | None = None,
 ):
     """
     Ingest content from various sources into the vector store.
@@ -70,7 +72,14 @@ def ingest(
     if console:
         console.print(f"Processing [bold]{len(texts)}[/bold] text chunks into vector store...")
     
-    create_vector_store(tenant, agent, texts, metadatas)
+    create_vector_store(
+        tenant,
+        agent,
+        texts,
+        metadatas,
+        provider=embedding_provider,
+        model=embedding_model,
+    )
     
     msg = f"Vector store created/updated successfully"
     if console:

--- a/watcher.py
+++ b/watcher.py
@@ -1,0 +1,47 @@
+"""Background ingestion watcher"""
+import time
+from argparse import ArgumentParser
+from pathlib import Path
+
+from .ingestion import ingest
+from .config import BASE_DIR
+
+
+def watch_folder(directory: Path, tenant: str, agent: str, interval: int, provider: str, model: str | None):
+    processed: dict[Path, float] = {}
+    directory.mkdir(parents=True, exist_ok=True)
+    while True:
+        files = [f for f in directory.iterdir() if f.is_file()]
+        changed = False
+        for f in files:
+            mtime = f.stat().st_mtime
+            if processed.get(f) != mtime:
+                changed = True
+            processed[f] = mtime
+        if changed and files:
+            ingest(
+                tenant,
+                agent,
+                files=files,
+                console=None,
+                embedding_provider=provider,
+                embedding_model=model,
+            )
+        time.sleep(interval)
+
+
+def main():
+    ap = ArgumentParser(description="Watch a folder and ingest files when updated")
+    ap.add_argument("--tenant", default="public")
+    ap.add_argument("--agent", default="default")
+    ap.add_argument("--uploads", type=Path, default=BASE_DIR / "uploads")
+    ap.add_argument("--interval", type=int, default=60)
+    ap.add_argument("--provider", default="openai", choices=["openai", "anthropic", "vertexai", "local"])
+    ap.add_argument("--model", default=None)
+    args = ap.parse_args()
+
+    watch_folder(args.uploads, args.tenant, args.agent, args.interval, args.provider, args.model)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `embedding.py` util with support for OpenAI, Anthropic, Vertex AI and local embeddings
- update `vectorstore` and `ingestion` to allow configurable embedding providers
- write `watcher.py` script that polls an upload folder on a timer and ingests new files

## Testing
- `python -m py_compile embedding.py vectorstore.py ingestion.py watcher.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68543ca69998832e895759f82fcb4448