### PR TITLE
Fix LLM import bug and improve test output

### DIFF
--- a/llm.py
+++ b/llm.py
@@ -5,7 +5,13 @@ import os
 import time
 from typing import List, Dict, Any
 
-from .database import log_llm_event
+# Import the logging function without assuming the module is part of a package.
+try:
+    # When llm.py is imported as part of the package (e.g. rag_chatbot.llm)
+    from .database import log_llm_event
+except Exception:  # pragma: no cover - fallback for direct script execution
+    # When executed as a stand-alone module (e.g. `python llm.py`)
+    from database import log_llm_event
 
 import openai
 

--- a/static/admin.html
+++ b/static/admin.html
@@ -1238,8 +1238,10 @@
                 if (response.ok) {
                     const data = await response.json();
                     resultDiv.textContent = `${new Date(data.timestamp).toLocaleString()} - ${data.message}`;
-                    if (data.openai_error) resultDiv.textContent += ` | OpenAI error: ${data.openai_error}`;
-                    if (data.anthropic_error) resultDiv.textContent += ` | Anthropic error: ${data.anthropic_error}`;
+                    resultDiv.textContent += ` | OpenAI: ${data.openai}`;
+                    if (data.openai_error) resultDiv.textContent += ` (${data.openai_error})`;
+                    resultDiv.textContent += ` | Anthropic: ${data.anthropic}`;
+                    if (data.anthropic_error) resultDiv.textContent += ` (${data.anthropic_error})`;
                     loadSettings();
                 } else {
                     resultDiv.textContent = 'Test failed';


### PR DESCRIPTION
## Summary
- fix relative import in `llm.py` so it works when imported as a script
- expand `/llm_test` endpoint to report provider statuses
- show individual provider results in the admin page

## Testing
- `python -m py_compile llm.py routers/admin_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68549b65c614832ea298e25fdbff0491