### PR TITLE
Fix llm imports for admin routes

### DIFF
--- a/routers/admin_routes.py
+++ b/routers/admin_routes.py
@@ -70,7 +70,7 @@ async def health_check():
         openai_error = "API key is missing"
     else:
         try:
-            from llm import _get_openai_response
+            from ..llm import _get_openai_response
 
             _get_openai_response([{"role": "user", "content": "ping"}])
             openai_status = "ready"
@@ -81,7 +81,7 @@ async def health_check():
         anthropic_error = "API key is missing"
     else:
         try:
-            from llm import _get_anthropic_response
+            from ..llm import _get_anthropic_response
 
             _get_anthropic_response([{"role": "user", "content": "ping"}])
             anthropic_status = "ready"
@@ -103,7 +103,7 @@ async def health_check():
 async def llm_test():
     """Manually test connectivity to the configured LLM providers"""
     from datetime import datetime, timezone
-    from llm import _get_openai_response, _get_anthropic_response
+    from ..llm import _get_openai_response, _get_anthropic_response
 
     openai_error = None
     anthropic_error = None


### PR DESCRIPTION
## Summary
- fix admin routes to import llm module relatively

## Testing
- `python - <<'PY'
import sys, pathlib
sys.path.insert(0, str(pathlib.Path('.').resolve().parent))
from cg_bot.routers.admin_routes import llm_test
import asyncio
print(asyncio.run(llm_test()))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68549ebd54a0832eab7094094cce0791