### PR TITLE
Improve session handling on file upload

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -1634,8 +1634,11 @@
                 });
 
                 const result = await response.json();
-                
-                if (response.ok) {
+
+                if (response.status === 401) {
+                    logout();
+                    showError('uploadResult', 'Session expired. Please log in again.');
+                } else if (response.ok) {
                     resultDiv.innerHTML = `<div class="success">${result.message}</div>`;
                     resultDiv.classList.remove('hidden');
                     e.target.reset();


### PR DESCRIPTION
## Summary
- show a helpful message when the admin file upload fails because the JWT expired

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_6854ae1acccc832eaf4dd1a21925e246