### PR TITLE
Fix OpenAI response parsing

### DIFF
--- a/llm.py
+++ b/llm.py
@@ -74,8 +74,8 @@ def _get_openai_response(messages: List[Dict], model: str = None, temperature: f
         raise
 
     return {
-        "content": rsp.choices[0].message["content"],
-        "tokens_out": rsp.usage.completion_tokens
+        "content": rsp.choices[0].message.content,
+        "tokens_out": rsp.usage.completion_tokens,
     }
 
 


### PR DESCRIPTION
## Summary
- adapt to OpenAI 1.x API response objects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68570c7ff090832e9d95c0d7323f0a35