### PR TITLE
Add compact user landing page

### DIFF
--- a/static/user.html
+++ b/static/user.html
@@ -32,8 +32,15 @@
         .btn-danger { background: var(--danger); }
         .hidden { display: none !important; }
         .header { background: var(--white); padding: 20px; border-radius: 12px; box-shadow: var(--shadow); margin-bottom: 20px; display: flex; justify-content: space-between; align-items: center; }
-        .agent-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; }
-        .agent-card { color: var(--white); padding: 20px; border-radius: 12px; box-shadow: var(--shadow); display: flex; flex-direction: column; justify-content: space-between; }
+        .agent-table { width: 100%; }
+        .agent-header, .agent-row { display: flex; align-items: center; padding: 8px; }
+        .agent-header { background: var(--gray-200); font-weight: 600; text-transform: uppercase; border-radius: 8px 8px 0 0; }
+        .agent-row { background: var(--white); margin-bottom: 4px; border-radius: 0 0 8px 8px; box-shadow: var(--shadow); }
+        .agent-row div { padding: 4px 8px; }
+        .col-num { width: 50px; }
+        .col-desc { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+        .col-action { width: 110px; text-align: center; }
+        .btn-small { padding: 6px 12px; font-size: 12px; }
     </style>
 </head>
 <body>
@@ -58,13 +65,22 @@
     <div id="agentPage" class="hidden">
         <div class="container">
             <div class="header">
-                <h1>Your Agents</h1>
+                <h1 id="tenantTitle">Digital Navigator</h1>
                 <div class="user-info">
                     <span id="userWelcome"></span>
                     <button id="logoutBtn" class="btn btn-danger">Logout</button>
                 </div>
             </div>
-            <div id="agentsContainer"></div>
+            <div class="agent-table">
+                <div class="agent-header">
+                    <div class="col-num">#</div>
+                    <div class="col-desc">Case Description</div>
+                    <div class="col-action">Open</div>
+                    <div class="col-action">Add Files</div>
+                    <div class="col-action">View Files</div>
+                </div>
+                <div id="agentsContainer"></div>
+            </div>
         </div>
     </div>
 
@@ -111,6 +127,7 @@ async function loadUser(){
     if(res.ok){
         currentUser = await res.json();
         document.getElementById('userWelcome').textContent = `Welcome, ${currentUser.username}!`;
+        document.getElementById('tenantTitle').textContent = `Digital Navigator for: ${currentUser.tenant}`;
         loadAgents();
     }
 }
@@ -127,33 +144,68 @@ function displayAgents(data){
     const container = document.getElementById('agentsContainer');
     container.innerHTML = '';
     const tenants = Array.isArray(data) ? data : [data];
+    let idx = 1;
     tenants.forEach(t => {
-        const section = document.createElement('section');
-        const h2 = document.createElement('h2');
-        h2.textContent = t.tenant;
-        section.appendChild(h2);
-        const grid = document.createElement('div');
-        grid.className = 'agent-grid';
         (t.agents || []).forEach(a => {
-            const card = document.createElement('div');
-            card.className = 'agent-card';
-            card.style.background = a.primary_color || '#1E88E5';
-            card.innerHTML = `<h3>${a.bot_name}</h3>`;
-            const btn = document.createElement('button');
-            btn.className = 'btn';
-            btn.textContent = 'Open';
-            btn.onclick = () => openAgent(t.tenant, a.agent);
-            card.appendChild(btn);
-            grid.appendChild(card);
+            const row = document.createElement('div');
+            row.className = 'agent-row';
+
+            const num = document.createElement('div');
+            num.className = 'col-num';
+            num.textContent = String(idx).padStart(3, '0');
+            row.appendChild(num);
+
+            const desc = document.createElement('div');
+            desc.className = 'col-desc';
+            desc.textContent = a.bot_name || a.agent;
+            row.appendChild(desc);
+
+            const openCol = document.createElement('div');
+            openCol.className = 'col-action';
+            const openBtn = document.createElement('button');
+            openBtn.className = 'btn btn-small';
+            openBtn.textContent = 'Open';
+            openBtn.onclick = () => openAgent(t.tenant, a.agent);
+            openCol.appendChild(openBtn);
+            row.appendChild(openCol);
+
+            const addCol = document.createElement('div');
+            addCol.className = 'col-action';
+            const addBtn = document.createElement('button');
+            addBtn.className = 'btn btn-small';
+            addBtn.textContent = 'Add Files';
+            addBtn.onclick = () => addFiles(t.tenant, a.agent);
+            addCol.appendChild(addBtn);
+            row.appendChild(addCol);
+
+            const viewCol = document.createElement('div');
+            viewCol.className = 'col-action';
+            const viewBtn = document.createElement('button');
+            viewBtn.className = 'btn btn-small';
+            viewBtn.textContent = 'View Files';
+            viewBtn.onclick = () => viewFiles(t.tenant, a.agent);
+            viewCol.appendChild(viewBtn);
+            row.appendChild(viewCol);
+
+            container.appendChild(row);
+            idx++;
         });
-        section.appendChild(grid);
-        container.appendChild(section);
     });
 }
 
 function openAgent(tenant, agent){
     const url = `/chat.html?tenant=${encodeURIComponent(tenant)}&agent=${encodeURIComponent(agent)}`;
     window.open(url, '_blank', 'width=1000,height=800,resizable=yes');
+}
+
+function addFiles(tenant, agent){
+    const url = `/admin.html?tenant=${encodeURIComponent(tenant)}&agent=${encodeURIComponent(agent)}#ingest`;
+    window.open(url, '_blank');
+}
+
+function viewFiles(tenant, agent){
+    const url = `/admin.html?tenant=${encodeURIComponent(tenant)}&agent=${encodeURIComponent(agent)}#files`;
+    window.open(url, '_blank');
 }
 
 function logout(){


### PR DESCRIPTION
## Summary
- redesign `user.html` for a cleaner user landing page
- show tenant title and compact agent list
- include actions to open, add files, and view files for each agent

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685714bff1fc832e8cd68cfff9f688ce