### PR TITLE
Enable per-user file upload permission

### DIFF
--- a/models.py
+++ b/models.py
@@ -12,6 +12,7 @@ class User(BaseModel):
     role: str = "user"
     disabled: bool = False
     agents: Optional[List[str]] = []
+    allow_files: bool = False
 
 
 class UserCreate(User):

--- a/routers/ingest_routes.py
+++ b/routers/ingest_routes.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Query, Depends, HTTPException, File, UploadFile
 from fastapi.responses import FileResponse
 
 from ..models import User
-from ..auth import get_admin_user
+from ..auth import get_admin_user, get_files_user
 from ..config import DEFAULT_TENANT, DEFAULT_AGENT, uploads_path
 from ..ingestion import ingest
 from ..vectorstore import clear_cache
@@ -28,7 +28,7 @@ async def upload_files(
     files: List[UploadFile] = File(...),
     tenant: str = Query(DEFAULT_TENANT),
     agent: str = Query(DEFAULT_AGENT),
-    current_user: User = Depends(get_admin_user)
+    current_user: User = Depends(get_files_user)
 ):
     """Upload and ingest files into the vector store"""
     
@@ -141,7 +141,7 @@ async def ingest_drive(
 async def get_files(
     tenant: str = Query(DEFAULT_TENANT),
     agent: str = Query(DEFAULT_AGENT),
-    current_user: User = Depends(get_admin_user),
+    current_user: User = Depends(get_files_user),
 ):
     """List uploaded files for a tenant/agent"""
 
@@ -164,7 +164,7 @@ async def get_files(
 @router.delete("/files/{file_id}")
 async def remove_file(
     file_id: int,
-    current_user: User = Depends(get_admin_user),
+    current_user: User = Depends(get_files_user),
 ):
     """Delete an uploaded file"""
 
@@ -186,7 +186,7 @@ async def remove_file(
 
 
 @router.get("/uploaded/{tenant}/{agent}/{filename}")
-async def serve_uploaded_file(tenant: str, agent: str, filename: str, current_user: User = Depends(get_admin_user)):
+async def serve_uploaded_file(tenant: str, agent: str, filename: str, current_user: User = Depends(get_files_user)):
     """Serve an uploaded file"""
     if current_user.tenant != "*" and current_user.tenant != tenant:
         raise HTTPException(status_code=403, detail="You don't have access to this tenant")

--- a/static/admin.html
+++ b/static/admin.html
@@ -586,6 +586,7 @@
                                 <th>Username</th>
                                 <th>Tenant</th>
                                 <th>Role</th>
+                                <th>Files</th>
                                 <th>Status</th>
                                 <th>Actions</th>
                             </tr>
@@ -677,6 +678,10 @@
                         <option value="user">User</option>
                         <option value="admin">Admin</option>
                     </select>
+                </div>
+                <div class="checkbox-group">
+                    <input type="checkbox" id="newUserFiles" name="allow_files">
+                    <label for="newUserFiles">Allow File Uploads</label>
                 </div>
                 <button type="submit" class="btn">Create User</button>
             </form>
@@ -1127,6 +1132,7 @@
                     <td>${user.username}</td>
                     <td>${user.tenant}</td>
                     <td>${user.role}</td>
+                    <td>${user.allow_files ? 'Yes' : 'No'}</td>
                     <td>${user.disabled ? '❌ Disabled' : '✅ Active'}</td>
                     <td>
                         <button class="btn btn-small" onclick="editUser('${user.username}')">Edit</button>
@@ -1505,7 +1511,8 @@
                 password: formData.get('password'),
                 tenant: formData.get('tenant'),
                 role: formData.get('role'),
-                disabled: false
+                disabled: false,
+                allow_files: formData.get('allow_files') === 'on'
             };
 
             try {
@@ -1536,18 +1543,21 @@
             // For simplicity, using prompt - in production, you'd want a proper modal
             const newTenant = prompt(`Enter new tenant for ${username} (current tenant will be preserved if empty):`);
             if (newTenant === null) return;
-            
+
             const newRole = prompt(`Enter new role for ${username} (admin/user):`);
             if (!['admin', 'user'].includes(newRole)) {
                 alert('Invalid role. Must be admin or user.');
                 return;
             }
 
+            const allowFiles = confirm('Allow file uploads for this user?');
+
             try {
                 const updateData = { role: newRole };
                 if (newTenant.trim()) {
                     updateData.tenant = newTenant.trim();
                 }
+                updateData.allow_files = allowFiles;
 
                 const response = await fetch(`${API_BASE}/users/${username}`, {
                     method: 'PUT',

--- a/static/user.html
+++ b/static/user.html
@@ -76,8 +76,8 @@
                     <div class="col-num">#</div>
                     <div class="col-desc">Case Description</div>
                     <div class="col-action">Open</div>
-                    <div class="col-action">Add Files</div>
-                    <div class="col-action">View Files</div>
+                    <div class="col-action file-col" id="addFilesHeader">Add Files</div>
+                    <div class="col-action file-col" id="viewFilesHeader">View Files</div>
                 </div>
                 <div id="agentsContainer"></div>
             </div>
@@ -128,6 +128,10 @@ async function loadUser(){
         currentUser = await res.json();
         document.getElementById('userWelcome').textContent = `Welcome, ${currentUser.username}!`;
         document.getElementById('tenantTitle').textContent = `Digital Navigator for: ${currentUser.tenant}`;
+        if(!currentUser.allow_files){
+            document.getElementById('addFilesHeader').classList.add('hidden');
+            document.getElementById('viewFilesHeader').classList.add('hidden');
+        }
         loadAgents();
     }
 }
@@ -169,23 +173,25 @@ function displayAgents(data){
             openCol.appendChild(openBtn);
             row.appendChild(openCol);
 
-            const addCol = document.createElement('div');
-            addCol.className = 'col-action';
-            const addBtn = document.createElement('button');
-            addBtn.className = 'btn btn-small';
-            addBtn.textContent = 'Add Files';
-            addBtn.onclick = () => addFiles(t.tenant, a.agent);
-            addCol.appendChild(addBtn);
-            row.appendChild(addCol);
+            if(currentUser.allow_files){
+                const addCol = document.createElement('div');
+                addCol.className = 'col-action';
+                const addBtn = document.createElement('button');
+                addBtn.className = 'btn btn-small';
+                addBtn.textContent = 'Add Files';
+                addBtn.onclick = () => addFiles(t.tenant, a.agent);
+                addCol.appendChild(addBtn);
+                row.appendChild(addCol);
 
-            const viewCol = document.createElement('div');
-            viewCol.className = 'col-action';
-            const viewBtn = document.createElement('button');
-            viewBtn.className = 'btn btn-small';
-            viewBtn.textContent = 'View Files';
-            viewBtn.onclick = () => viewFiles(t.tenant, a.agent);
-            viewCol.appendChild(viewBtn);
-            row.appendChild(viewCol);
+                const viewCol = document.createElement('div');
+                viewCol.className = 'col-action';
+                const viewBtn = document.createElement('button');
+                viewBtn.className = 'btn btn-small';
+                viewBtn.textContent = 'View Files';
+                viewBtn.onclick = () => viewFiles(t.tenant, a.agent);
+                viewCol.appendChild(viewBtn);
+                row.appendChild(viewCol);
+            }
 
             container.appendChild(row);
             idx++;
@@ -199,11 +205,19 @@ function openAgent(tenant, agent){
 }
 
 function addFiles(tenant, agent){
+    if(!currentUser.allow_files){
+        alert('File access is disabled for your account');
+        return;
+    }
     const url = `/user_upload.html?tenant=${encodeURIComponent(tenant)}&agent=${encodeURIComponent(agent)}`;
     window.open(url, '_blank');
 }
 
 function viewFiles(tenant, agent){
+    if(!currentUser.allow_files){
+        alert('File access is disabled for your account');
+        return;
+    }
     const url = `/user_files.html?tenant=${encodeURIComponent(tenant)}&agent=${encodeURIComponent(agent)}`;
     window.open(url, '_blank');
 }

--- a/static/user_files.html
+++ b/static/user_files.html
@@ -29,8 +29,21 @@ const agent = params.get('agent');
 const API_BASE = '';
 const authToken = localStorage.getItem('rag_auth_token');
 const tbody = document.querySelector('#filesTable tbody');
+let currentUser = null;
 
-load();
+init();
+
+async function init(){
+    const res = await fetch(`${API_BASE}/users/me`,{headers:{Authorization:`Bearer ${authToken}`}});
+    if(res.ok){
+        currentUser = await res.json();
+        if(!currentUser.allow_files){
+            document.body.innerHTML = '<p>File access is disabled for your account.</p>';
+            return;
+        }
+    }
+    load();
+}
 async function load(){
     const res = await fetch(`${API_BASE}/files?tenant=${tenant}&agent=${agent}`,{headers:{Authorization:`Bearer ${authToken}`}});
     if(res.ok){
@@ -49,6 +62,7 @@ async function load(){
 }
 
 async function del(id){
+    if(currentUser && !currentUser.allow_files) return;
     if(!confirm('Delete file?')) return;
     const res = await fetch(`${API_BASE}/files/${id}`,{method:'DELETE', headers:{Authorization:`Bearer ${authToken}`}});
     if(res.ok) load();

--- a/static/user_upload.html
+++ b/static/user_upload.html
@@ -26,6 +26,20 @@ const tenant = params.get('tenant');
 const agent = params.get('agent');
 const API_BASE = '';
 const authToken = localStorage.getItem('rag_auth_token');
+let currentUser = null;
+
+init();
+
+async function init(){
+    const res = await fetch(`${API_BASE}/users/me`,{headers:{Authorization:`Bearer ${authToken}`}});
+    if(res.ok){
+        currentUser = await res.json();
+        if(!currentUser.allow_files){
+            document.body.innerHTML = '<p>File access is disabled for your account.</p>';
+            return;
+        }
+    }
+}
 
 const dropZone = document.getElementById('dropZone');
 const fileInput = document.getElementById('fileInput');
@@ -38,7 +52,7 @@ dropZone.addEventListener('drop', e => { e.preventDefault(); dropZone.classList.
 document.getElementById('fileSelect').addEventListener('click', () => fileInput.click());
 
 async function uploadFiles(files){
-    if(!files.length) return;
+    if(!files.length || (currentUser && !currentUser.allow_files)) return;
     const fd = new FormData();
     for(const f of files){ fd.append('files', f); }
     const res = await fetch(`${API_BASE}/upload?tenant=${tenant}&agent=${agent}`,{ method:'POST', headers:{ 'Authorization':`Bearer ${authToken}` }, body:fd });

--- a/users.json
+++ b/users.json
@@ -4,6 +4,7 @@
     "tenant": "*",
     "role": "system_admin",
     "agents": [],
+    "allow_files": true,
     "hashed_password": "$2b$12$QJJmC4jT9RriTGXB2J73S./R0DHYlFrjGt2fTObeuhFDGKwaPlOuy",
     "disabled": false
   }


### PR DESCRIPTION
## Summary
- add `allow_files` field to `User`
- grant access to upload endpoints through new `get_files_user`
- show/hide upload UI based on user permissions
- allow admins to manage file permissions in the dashboard

## Testing
- `pytest -q`
- `python -m py_compile auth.py routers/ingest_routes.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_685722b3d70c832e8a3c1696d1683eb7