### PR TITLE
Fix config JSON and warn on duplicate file uploads

### DIFF
--- a/configs/mycompany/support.json
+++ b/configs/mycompany/support.json
@@ -1,11 +1,13 @@
-"bot_name": "Support Bot",
-"system_prompt": "You are a helpful customer service assistant"
-"primary_color": "#1E88E5",
-"secondary_color": "#FFFFFF",
-"avatar_url": "",
-"mode": "inline",
-"auto_open": false,
-"llm_provider": "openai",
-"llm_model": "gpt-4o-mini",
-"temperature": 0.3,
-"allowed_domain": ["*"]
+{
+  "bot_name": "Support Bot",
+  "system_prompt": "You are a helpful customer service assistant",
+  "primary_color": "#1E88E5",
+  "secondary_color": "#FFFFFF",
+  "avatar_url": "",
+  "mode": "inline",
+  "auto_open": false,
+  "llm_provider": "openai",
+  "llm_model": "gpt-4o-mini",
+  "temperature": 0.3,
+  "allowed_domains": ["*"]
+}

--- a/database.py
+++ b/database.py
@@ -169,6 +169,16 @@ def delete_uploaded_file(file_id: int):
         con.commit()
 
 
+def delete_uploaded_file_by_name(tenant: str, agent: str, filename: str) -> None:
+    """Remove file record matching tenant, agent and filename"""
+    with get_db() as con:
+        con.execute(
+            "DELETE FROM uploaded_files WHERE tenant = ? AND agent = ? AND filename = ?",
+            (tenant, agent, filename),
+        )
+        con.commit()
+
+
 def get_uploaded_file(file_id: int):
     """Get metadata for a single uploaded file"""
     with get_db() as con:

--- a/static/user_upload.html
+++ b/static/user_upload.html
@@ -51,14 +51,22 @@ dropZone.addEventListener('dragleave', () => dropZone.classList.remove('hover'))
 dropZone.addEventListener('drop', e => { e.preventDefault(); dropZone.classList.remove('hover'); uploadFiles(e.dataTransfer.files); });
 document.getElementById('fileSelect').addEventListener('click', () => fileInput.click());
 
-async function uploadFiles(files){
+async function uploadFiles(files, replace=false){
     if(!files.length || (currentUser && !currentUser.allow_files)) return;
     const fd = new FormData();
     for(const f of files){ fd.append('files', f); }
-    const res = await fetch(`${API_BASE}/upload?tenant=${tenant}&agent=${agent}`,{ method:'POST', headers:{ 'Authorization':`Bearer ${authToken}` }, body:fd });
+    const url = `${API_BASE}/upload?tenant=${tenant}&agent=${agent}${replace ? '&replace=true' : ''}`;
+    const res = await fetch(url,{ method:'POST', headers:{ 'Authorization':`Bearer ${authToken}` }, body:fd });
     if(res.ok){
         result.textContent = 'Upload successful';
         fileInput.value = '';
+    }else if(res.status === 409 && !replace){
+        const data = await res.json().catch(()=>({detail:'File exists'}));
+        if(confirm(`${data.detail} Replace?`)){
+            await uploadFiles(files, true);
+        } else {
+            result.textContent = 'Upload canceled';
+        }
     }else{
         const data = await res.json().catch(()=>({detail:'Upload failed'}));
         result.textContent = data.detail || 'Upload failed';


### PR DESCRIPTION
## Summary
- fix malformed JSON config for the example tenant
- add `replace` option to file upload endpoint
- warn about duplicate uploads and allow replacing files
- update upload page script to handle duplicate checks
- track files by name in DB when replacing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68572d13695c832eaa1ed913f22cd3ce