### PR TITLE
Improve file auth and analytics

### DIFF
--- a/database.py
+++ b/database.py
@@ -189,6 +189,22 @@ def get_uploaded_file(file_id: int):
         return cur.fetchone()
 
 
+def count_uploaded_files(tenant: str, agent: str | None = None) -> int:
+    """Return number of uploaded files for a tenant or specific agent."""
+    with get_db() as con:
+        if agent is not None:
+            cur = con.execute(
+                "SELECT COUNT(*) FROM uploaded_files WHERE tenant = ? AND agent = ?",
+                (tenant, agent),
+            )
+        else:
+            cur = con.execute(
+                "SELECT COUNT(*) FROM uploaded_files WHERE tenant = ?",
+                (tenant,),
+            )
+        return cur.fetchone()[0]
+
+
 def update_feedback(chat_id: int, feedback: int):
     """Update feedback for a chat interaction"""
     with get_db() as con:

--- a/embedding.py
+++ b/embedding.py
@@ -1,6 +1,11 @@
 """Embedding provider utilities"""
 from typing import Optional
 
+try:
+    from .database import log_llm_event
+except Exception:  # pragma: no cover
+    from database import log_llm_event
+
 
 def get_embedding_model(provider: str = "openai", model: Optional[str] = None):
     """Return a LangChain embedding model for the given provider."""
@@ -9,25 +14,34 @@ def get_embedding_model(provider: str = "openai", model: Optional[str] = None):
         try:
             from langchain_openai import OpenAIEmbeddings
         except ModuleNotFoundError as e:  # pragma: no cover - optional deps
+            log_llm_event("openai-embed", "error", str(e))
             raise ImportError("langchain_openai package not installed") from e
+        log_llm_event("openai-embed", "success", None)
         return OpenAIEmbeddings(model=model or "text-embedding-3-small")
     elif provider == "anthropic":
         try:
             from langchain_community.embeddings import AnthropicEmbeddings
         except ModuleNotFoundError as e:  # pragma: no cover - optional deps
+            log_llm_event("anthropic-embed", "error", str(e))
             raise ImportError("Anthropic dependencies not installed") from e
+        log_llm_event("anthropic-embed", "success", None)
         return AnthropicEmbeddings(model=model or "claude-3-embedding-001")
     elif provider in {"vertexai", "google"}:
         try:
             from langchain_google_vertexai import VertexAIEmbeddings
         except ModuleNotFoundError as e:  # pragma: no cover - optional deps
+            log_llm_event("vertexai-embed", "error", str(e))
             raise ImportError("google-cloud-aiplatform package not installed") from e
+        log_llm_event("vertexai-embed", "success", None)
         return VertexAIEmbeddings(model_name=model or "textembedding-gecko@001")
     elif provider == "local":
         try:
             from langchain_community.embeddings import HuggingFaceEmbeddings
         except ModuleNotFoundError as e:  # pragma: no cover - optional deps
+            log_llm_event("local-embed", "error", str(e))
             raise ImportError("sentence-transformers package not installed") from e
+        log_llm_event("local-embed", "success", None)
         return HuggingFaceEmbeddings(model_name=model or "sentence-transformers/all-MiniLM-L6-v2")
     else:
+        log_llm_event("embedding", "error", f"Unknown provider: {provider}")
         raise ValueError(f"Unknown embedding provider: {provider}")

--- a/static/admin.html
+++ b/static/admin.html
@@ -1220,6 +1220,10 @@
                     <div class="stat-number">${data.storage_gb?.toFixed(2) || '0'}</div>
                     <div class="stat-label">Vector Store (GB)</div>
                 </div>
+                <div class="stat-card">
+                    <div class="stat-number">${data.file_count || 0}</div>
+                    <div class="stat-label">Files in Vector DB</div>
+                </div>
             </div>
             `;
         }

--- a/static/user_files.html
+++ b/static/user_files.html
@@ -51,7 +51,8 @@ async function load(){
         tbody.innerHTML = '';
         data.forEach(f => {
             const tr = document.createElement('tr');
-            tr.innerHTML = `<td><a href="/uploaded/${tenant}/${agent}/${encodeURIComponent(f.filename)}" target="_blank">${f.filename} \u2197</a></td>`+
+            const fileUrl = `/uploaded/${tenant}/${agent}/${encodeURIComponent(f.filename)}?token=${encodeURIComponent(authToken)}`;
+            tr.innerHTML = `<td><a href="${fileUrl}" target="_blank">${f.filename} \u2197</a></td>`+
                              `<td>${(f.size/1024).toFixed(1)} KB</td>`+
                              `<td>${new Date(f.uploaded_at).toLocaleString()}</td>`+
                              `<td>${f.status}</td>`+


### PR DESCRIPTION
## Summary
- allow token query param for uploaded file downloads
- link user files with auth token
- add helper to decode JWTs
- log embedding model events to LLM logs
- include file counts and vector store size in analytics output
- show file count on admin analytics page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685732ce3290832e9904af082c5ccaab