### PR TITLE
Fix missing Header import

### DIFF
--- a/routers/ingest_routes.py
+++ b/routers/ingest_routes.py
@@ -4,7 +4,15 @@ routers/ingest_routes.py - Document ingestion endpoints
 
 from typing import List
 
-from fastapi import APIRouter, Query, Depends, HTTPException, File, UploadFile
+from fastapi import (
+    APIRouter,
+    Query,
+    Depends,
+    HTTPException,
+    File,
+    UploadFile,
+    Header,
+)
 from fastapi.responses import FileResponse
 
 from ..models import User


### PR DESCRIPTION
## Summary
- include `Header` dependency to support auth header in `serve_uploaded_file`

## Testing
- `pytest -q`
- `pytest tests/ -q` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_685736745294832e82391a410c2fc7da