### PR TITLE
Improve chat UI, fix vector store load

### DIFF
--- a/static/chat.html
+++ b/static/chat.html
@@ -5,8 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Chat</title>
     <style>
-        body, html {height:100%;margin:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:#f5f5f5;}
-        #chatContainer{display:flex;flex-direction:column;height:100vh;max-width:800px;margin:10px auto;border:1px solid #ccc;border-radius:8px;background:#fff;}
+        body, html {height:100%;margin:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#f5f5f5;}
+        #layout{display:flex;height:100vh;}
+        #historyPanel{width:250px;background:#fafafa;border-right:1px solid #ccc;overflow-y:auto;transition:transform .3s;position:relative;}
+        #historyPanel.collapsed{transform:translateX(-100%);}        
+        #toggleHistory{position:absolute;top:10px;right:-25px;width:25px;height:25px;border:none;background:#1E88E5;color:#fff;border-radius:4px;cursor:pointer;}
+        #historyList{list-style:none;margin:0;padding:40px 0 10px 0;}
+        #historyList li{padding:8px 12px;border-bottom:1px solid #ddd;font-size:14px;cursor:pointer;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+        #chatContainer{display:flex;flex-direction:column;flex:1;max-width:800px;margin:10px auto;border:1px solid #ccc;border-radius:8px;background:#fff;}
         header{display:flex;align-items:center;justify-content:space-between;padding:10px;border-bottom:1px solid #ccc;background:#fafafa;}
         #messages{flex:1;overflow-y:auto;padding:10px;}
         .msg{margin-bottom:10px;padding:8px 12px;border-radius:8px;max-width:80%;}
@@ -20,16 +26,22 @@
     </style>
 </head>
 <body>
-<div id="chatContainer">
-    <header>
-        <button id="backBtn">Home</button>
-        <h2 id="chatTitle">Chat</h2>
-    </header>
-    <div id="messages"></div>
+<div id="layout">
+    <div id="historyPanel" class="collapsed">
+        <button id="toggleHistory">›</button>
+        <ul id="historyList"></ul>
+    </div>
+    <div id="chatContainer">
+        <header>
+            <button id="backBtn">Home</button>
+            <h2 id="chatTitle">Chat</h2>
+        </header>
+        <div id="messages"></div>
     <form id="chatForm">
         <input id="chatInput" type="text" placeholder="Type your message..." autocomplete="off"/>
         <button type="submit">Send</button>
-    </form>
+        </form>
+    </div>
 </div>
 <script>
 const params=new URLSearchParams(location.search);
@@ -44,6 +56,15 @@ chatTitle.textContent=`Chat with ${agent}`;
 
 document.getElementById('backBtn').onclick=()=>{window.location.href='/user.html'};
 
+const historyPanel=document.getElementById('historyPanel');
+const toggleHistory=document.getElementById('toggleHistory');
+const historyList=document.getElementById('historyList');
+
+toggleHistory.addEventListener('click',()=>{
+    historyPanel.classList.toggle('collapsed');
+    toggleHistory.textContent=historyPanel.classList.contains('collapsed')?'›':'‹';
+});
+
 function addMessage(text,cls){
     const div=document.createElement('div');
     div.className='msg '+cls;
@@ -56,7 +77,14 @@ async function loadHistory(){
     const res=await fetch(`/history?tenant=${tenant}&agent=${agent}&limit=25`,{headers:{Authorization:`Bearer ${token}`}});
     if(res.ok){
         const data=await res.json();
-        data.forEach(i=>{addMessage(i.question,'user');addMessage(i.answer,'bot');});
+        data.forEach((i,idx)=>{
+            addMessage(i.question,'user');
+            addMessage(i.answer,'bot');
+            const li=document.createElement('li');
+            li.textContent=i.question;
+            li.onclick=()=>sendMessage(i.question);
+            historyList.appendChild(li);
+        });
     }
 }
 

--- a/vectorstore.py
+++ b/vectorstore.py
@@ -67,7 +67,11 @@ def get_vector_store(tenant: str, agent: str) -> FAISS:
     emb = get_embedding_model(meta["provider"], meta.get("model"))
 
     # Load and cache
-    _vec_cache[cache_key] = FAISS.load_local(str(path), emb)
+    _vec_cache[cache_key] = FAISS.load_local(
+        str(path),
+        emb,
+        allow_dangerous_deserialization=True,
+    )
     return _vec_cache[cache_key]
 
 


### PR DESCRIPTION
## Summary
- allow FAISS dangerous deserialization so vector store loads
- restyle chat.html and add collapsible history sidebar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68575023bd40832e8aba353086e1ceaf