### PR TITLE
Add local-only option to agent config

### DIFF
--- a/config.py
+++ b/config.py
@@ -51,7 +51,11 @@ def load_config(tenant: str, agent: str) -> Dict[str, Any]:
     """Load configuration for a tenant/agent"""
     p = cfg_path(tenant, agent)
     if p.exists():
-        return json.loads(p.read_text())
+        cfg = json.loads(p.read_text())
+        if "local_only" not in cfg:
+            cfg["local_only"] = True
+            p.write_text(json.dumps(cfg, indent=2))
+        return cfg
 
     # Create default configuration
     p.parent.mkdir(parents=True, exist_ok=True)
@@ -67,6 +71,7 @@ def load_config(tenant: str, agent: str) -> Dict[str, Any]:
         "llm_model": "gpt-4o-mini",
         "temperature": 0.3,
         "allowed_domains": ["*"],
+        "local_only": True,
         # Enhanced widget parameters
         "enable_voice": True,
         "enable_files": True,

--- a/models.py
+++ b/models.py
@@ -57,6 +57,7 @@ class ConfigUpdateRequest(BaseModel):
     llm_model: Optional[str] = None
     temperature: Optional[float] = None
     allowed_domains: Optional[List[str]] = None
+    local_only: Optional[bool] = None
 
 
 class EnhancedConfigUpdateRequest(ConfigUpdateRequest):

--- a/routers/chat_routes.py
+++ b/routers/chat_routes.py
@@ -44,9 +44,13 @@ async def chat(
     ctx = "\n".join(content for content, _, _ in search_results)
     
     # Create system message with context
+    sys_content = cfg["system_prompt"]
+    if cfg.get("local_only", True):
+        sys_content += "\nUse only the provided Context to answer. Do not search the internet."
+    sys_content += "\nContext:\n" + ctx
     system_msg = {
         "role": "system",
-        "content": cfg["system_prompt"] + "\nContext:\n" + ctx
+        "content": sys_content
     }
     
     # Get response from LLM

--- a/static/admin.html
+++ b/static/admin.html
@@ -764,6 +764,10 @@
                             <input type="range" id="temperature" name="temperature" min="0" max="1" step="0.1" value="0.3">
                             <span id="tempValue">0.3</span>
                         </div>
+                        <div class="checkbox-group">
+                            <input type="checkbox" id="localOnly" name="local_only" checked>
+                            <label for="localOnly">Local Data Only</label>
+                        </div>
                     </div>
                     
                     <div class="config-section">
@@ -1429,6 +1433,7 @@
             document.getElementById('llmModel').value = config.llm_model || 'gpt-4o-mini';
             document.getElementById('temperature').value = config.temperature || 0.3;
             document.getElementById('tempValue').textContent = config.temperature || 0.3;
+            document.getElementById('localOnly').checked = config.local_only !== false;
             document.getElementById('enableVoice').checked = config.enable_voice !== false;
             document.getElementById('enableFiles').checked = config.enable_files !== false;
             document.getElementById('enableTTS').checked = config.enable_tts || false;
@@ -1456,6 +1461,7 @@
                 llm_provider: formData.get('llm_provider'),
                 llm_model: formData.get('llm_model'),
                 temperature: parseFloat(formData.get('temperature')),
+                local_only: formData.has('local_only'),
                 enable_voice: formData.has('enable_voice'),
                 enable_files: formData.has('enable_files'),
                 enable_tts: formData.has('enable_tts'),


### PR DESCRIPTION
## Summary
- allow storing a `local_only` setting for each agent
- respect the new setting when building the system prompt
- expose checkbox in admin UI to toggle the option
- include the field in configuration update models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685752c824a0832eb1775bfc9799ebd3