### PR TITLE
Add file info to embed logs

### DIFF
--- a/ingestion.py
+++ b/ingestion.py
@@ -12,7 +12,6 @@ from .vectorstore import create_vector_store, chunk_text
 from .utils.google_drive import list_drive_files, download_drive_file
 from .utils.web_scraper import parse_sitemap, download_page
 from .utils.file_processors import process_file
-from .database import log_llm_event
 
 
 def ingest(
@@ -151,25 +150,11 @@ def _ingest_from_files(
                 chunks, metas = process_file(file_path, file_path.name)
                 texts.extend(chunks)
                 metadatas.extend(metas)
-                log_llm_event(
-                    f"{provider}-embed",
-                    "success",
-                    tenant=tenant,
-                    agent=agent,
-                    description=file_path.name,
-                )
     else:
         for file_path in files:
             chunks, metas = process_file(file_path, file_path.name)
             texts.extend(chunks)
             metadatas.extend(metas)
-            log_llm_event(
-                f"{provider}-embed",
-                "success",
-                tenant=tenant,
-                agent=agent,
-                description=file_path.name,
-            )
     
     return texts, metadatas
 


### PR DESCRIPTION
## Summary
- log each embedded file by tenant and agent when creating vector store
- clean up unused log import in ingestion module

## Testing
- `python -m py_compile ingestion.py vectorstore.py`

------
https://chatgpt.com/codex/tasks/task_e_6857730988f4832ea7e37840a5d093e2