### PR TITLE
Fix invalid date in chat history

### DIFF
--- a/routers/chat_routes.py
+++ b/routers/chat_routes.py
@@ -134,12 +134,12 @@ async def chat_history(
 
     with get_db() as con:
         cur = con.execute(
-            "SELECT question, answer FROM chat_logs WHERE tenant = ? AND agent = ? ORDER BY id DESC LIMIT ?",
+            "SELECT ts, question, answer FROM chat_logs WHERE tenant = ? AND agent = ? ORDER BY id DESC LIMIT ?",
             (tenant, agent, limit),
         )
         rows = cur.fetchall()
 
     return [
-        {"question": q, "answer": a}
-        for q, a in reversed(rows)
+        {"timestamp": ts, "question": q, "answer": a}
+        for ts, q, a in reversed(rows)
     ]

--- a/static/chat.html
+++ b/static/chat.html
@@ -133,7 +133,11 @@ function renderHistory(){
         title.textContent=item.question.slice(0,30);
         const preview=document.createElement('div');
         preview.className='preview';
-        preview.textContent=new Date(item.timestamp).toLocaleString();
+        if(item.timestamp){
+            preview.textContent=new Date(item.timestamp).toLocaleString();
+        }else{
+            preview.textContent='';
+        }
         li.appendChild(title);
         li.appendChild(preview);
         li.onclick=()=>sendMessage(item.question);


### PR DESCRIPTION
## Summary
- return timestamps in `/history`
- guard against missing timestamps in chat UI

## Testing
- `python -m py_compile routers/chat_routes.py`

------
https://chatgpt.com/codex/tasks/task_e_6858b508e818832ea62951f9056fdc7d