### PR TITLE
Add admin action bar in user page

### DIFF
--- a/static/user.html
+++ b/static/user.html
@@ -42,6 +42,8 @@
         .col-action { width: 110px; text-align: center; }
         .col-files { width: 70px; text-align: center; }
         .btn-small { padding: 6px 12px; font-size: 12px; }
+        .action-bar { background: var(--white); padding: 8px 12px; border-radius: 8px; box-shadow: var(--shadow); margin-bottom: 10px; display: flex; align-items: center; }
+        .action-bar .col-label { flex: 1; font-weight: 600; }
     </style>
 </head>
 <body>
@@ -72,6 +74,11 @@
                     <button id="logoutBtn" class="btn btn-danger">Logout</button>
                 </div>
             </div>
+            <div id="adminMenu" class="action-bar hidden">
+                <div class="col-label">ACTIONS</div>
+                <div class="col-action"><button id="addCaseBtn" class="btn btn-small">Add Case</button></div>
+                <div class="col-action"><button id="manageUsersBtn" class="btn btn-small">Manage Users</button></div>
+            </div>
             <div class="agent-table">
                 <div class="agent-header">
                     <div class="col-num">#</div>
@@ -97,6 +104,8 @@ if(authToken){
 
 document.getElementById('loginForm').addEventListener('submit', handleLogin);
 document.getElementById('logoutBtn').addEventListener('click', logout);
+document.getElementById('addCaseBtn').addEventListener('click', () => window.open('/admin.html', '_blank'));
+document.getElementById('manageUsersBtn').addEventListener('click', () => window.open('/admin.html', '_blank'));
 
 async function handleLogin(e){
     e.preventDefault();
@@ -136,6 +145,11 @@ async function loadUser(){
             document.getElementById('fileCountHeader').classList.add('hidden');
         } else {
             document.getElementById('fileCountHeader').classList.remove('hidden');
+        }
+        if(currentUser.role === 'admin' && currentUser.allow_files){
+            document.getElementById('adminMenu').classList.remove('hidden');
+        } else {
+            document.getElementById('adminMenu').classList.add('hidden');
         }
         loadAgents();
     }


### PR DESCRIPTION
## Summary
- add a slim ACTIONS bar in `user.html` with Add Case and Manage Users buttons
- show the bar for admin users with file permissions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b5e290c94832ea592c2277c0bda3a