### PR TITLE
Add agent selection when creating users

### DIFF
--- a/routers/config_routes.py
+++ b/routers/config_routes.py
@@ -167,10 +167,11 @@ async def get_my_agents(current_user: User = Depends(get_current_active_user)):
     
     agents = []
     allowed = set(current_user.agents or [])
+    wildcard = '*' in allowed
     for config_file in tenant_dir.iterdir():
         if config_file.is_file() and config_file.suffix == ".json":
             agent_name = config_file.stem
-            if allowed and agent_name not in allowed:
+            if allowed and not wildcard and agent_name not in allowed:
                 continue
             config = load_config(user_tenant, agent_name)
 

--- a/static/admin.html
+++ b/static/admin.html
@@ -585,6 +585,7 @@
                             <tr>
                                 <th>Username</th>
                                 <th>Tenant</th>
+                                <th>Agents</th>
                                 <th>Role</th>
                                 <th>File Permissions</th>
                                 <th>Status</th>
@@ -670,6 +671,12 @@
                     <label for="newUserTenant">Tenant</label>
                     <select id="newUserTenant" name="tenant" required>
                         <option value="*">All Tenants (Admin)</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="newUserAgent">Agent</label>
+                    <select id="newUserAgent" name="agent" required>
+                        <option value="*">All Agents</option>
                     </select>
                 </div>
                 <div class="form-group">
@@ -889,6 +896,10 @@
             document.getElementById('createUserForm').addEventListener('submit', handleCreateUser);
             document.getElementById('agentConfigForm').addEventListener('submit', handleSaveAgentConfig);
             document.getElementById('uploadForm').addEventListener('submit', handleFileUpload);
+
+            document.getElementById('newUserTenant').addEventListener('change', function() {
+                loadAgentsForTenant(this.value);
+            });
             
             // Temperature slider
             document.getElementById('temperature').addEventListener('input', function() {
@@ -1136,9 +1147,11 @@
 
             users.forEach(user => {
                 const row = document.createElement('tr');
+                const agentsText = !user.agents || user.agents.length === 0 || user.agents.includes('*') ? '*' : user.agents.join(', ');
                 row.innerHTML = `
                     <td>${user.username}</td>
                     <td>${user.tenant}</td>
+                    <td>${agentsText}</td>
                     <td>${user.role}</td>
                     <td><input type="checkbox" class="filePermToggle" data-user="${user.username}" ${user.allow_files ? 'checked' : ''} ${(currentUser.role === 'admin' || currentUser.role === 'system_admin') ? '' : 'disabled'}></td>
                     <td>${user.disabled ? '❌ Disabled' : '✅ Active'}</td>
@@ -1525,9 +1538,47 @@
                         option.textContent = tenant.tenant;
                         select.appendChild(option);
                     });
+
+                    loadAgentsForTenant(select.value);
                 }
             } catch (error) {
                 console.error('Failed to load tenants for user:', error);
+            }
+        }
+
+        async function loadAgentsForTenant(tenant) {
+            const select = document.getElementById('newUserAgent');
+            if (!select) return;
+            select.innerHTML = '';
+
+            const optAll = document.createElement('option');
+            optAll.value = '*';
+            optAll.textContent = 'All Agents';
+            select.appendChild(optAll);
+
+            if (!tenant || tenant === '*') {
+                return;
+            }
+
+            try {
+                const response = await fetch(`${API_BASE}/tenants`, {
+                    headers: { 'Authorization': `Bearer ${authToken}` }
+                });
+
+                if (response.ok) {
+                    const tenants = await response.json();
+                    const t = tenants.find(t => t.tenant === tenant);
+                    if (t) {
+                        t.agents.forEach(agent => {
+                            const option = document.createElement('option');
+                            option.value = agent;
+                            option.textContent = agent;
+                            select.appendChild(option);
+                        });
+                    }
+                }
+            } catch (error) {
+                console.error('Failed to load agents for user:', error);
             }
         }
 
@@ -1539,6 +1590,7 @@
                 username: formData.get('username'),
                 password: formData.get('password'),
                 tenant: formData.get('tenant'),
+                agents: [formData.get('agent')],
                 role: formData.get('role'),
                 disabled: false,
                 allow_files: formData.get('allow_files') === 'on'


### PR DESCRIPTION
## Summary
- update admin UI to support assigning an agent when creating a user
- show agent column in users table
- dynamically load available agents per tenant
- allow `*` as wildcard for all agents

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b61a7bcc0832ebab097e0d5687a82