### PR TITLE
Add create case modal to user interface

### DIFF
--- a/static/user.html
+++ b/static/user.html
@@ -44,6 +44,51 @@
         .btn-small { padding: 6px 12px; font-size: 12px; }
         .action-bar { background: var(--white); padding: 8px 12px; border-radius: 8px; box-shadow: var(--shadow); margin-bottom: 10px; display: flex; align-items: center; }
         .action-bar .col-label { flex: 1; font-weight: 600; }
+
+        /* Modal styling copied from admin interface */
+        .modal {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.5);
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            z-index: 1000;
+        }
+
+        .modal-content {
+            background: var(--white);
+            border-radius: 12px;
+            padding: 30px;
+            max-width: 600px;
+            width: 90%;
+            max-height: 80vh;
+            overflow-y: auto;
+        }
+
+        .modal-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 20px;
+        }
+
+        .modal-title {
+            font-size: 20px;
+            font-weight: 600;
+            color: var(--gray-800);
+        }
+
+        .close-btn {
+            background: none;
+            border: none;
+            font-size: 24px;
+            cursor: pointer;
+            color: var(--gray-600);
+        }
     </style>
 </head>
 <body>
@@ -93,6 +138,23 @@
         </div>
     </div>
 
+    <!-- Create Case Modal -->
+    <div id="createCaseModal" class="modal hidden">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3 class="modal-title">Create New Case</h3>
+                <button class="close-btn" onclick="closeModal('createCaseModal')">&times;</button>
+            </div>
+            <form id="createCaseForm">
+                <div class="form-group">
+                    <label for="caseName">Case Name</label>
+                    <input type="text" id="caseName" name="caseName" required>
+                </div>
+                <button type="submit" class="btn">Create Case</button>
+            </form>
+        </div>
+    </div>
+
 <script>
 const API_BASE = '';
 let authToken = localStorage.getItem('rag_auth_token');
@@ -104,8 +166,12 @@ if(authToken){
 
 document.getElementById('loginForm').addEventListener('submit', handleLogin);
 document.getElementById('logoutBtn').addEventListener('click', logout);
-document.getElementById('addCaseBtn').addEventListener('click', () => window.open('/admin.html', '_blank'));
+document.getElementById('addCaseBtn').addEventListener('click', () => {
+    document.getElementById('createCaseForm').reset();
+    showModal('createCaseModal');
+});
 document.getElementById('manageUsersBtn').addEventListener('click', () => window.open('/admin.html', '_blank'));
+document.getElementById('createCaseForm').addEventListener('submit', handleCreateCase);
 
 async function handleLogin(e){
     e.preventDefault();
@@ -258,6 +324,45 @@ async function loadFileCount(tenant, agent, el){
         }
     }catch(e){
         el.textContent = '0';
+    }
+}
+
+// Modal helpers
+function showModal(modalId){
+    document.getElementById(modalId).classList.remove('hidden');
+}
+
+function closeModal(modalId){
+    document.getElementById(modalId).classList.add('hidden');
+}
+
+// Handle creation of a new case (agent)
+async function handleCreateCase(e){
+    e.preventDefault();
+    const fd = new FormData(e.target);
+    const caseName = fd.get('caseName');
+    if(!caseName) return;
+    const configData = {
+        bot_name: `${currentUser.tenant} ${caseName} Bot`,
+        system_prompt: `You are a helpful assistant for ${currentUser.tenant}.`,
+        primary_color: '#1E88E5',
+        secondary_color: '#FFFFFF',
+        placeholder_text: 'Please ask your question...'
+    };
+    try{
+        const res = await fetch(`${API_BASE}/config?tenant=${currentUser.tenant}&agent=${caseName}`, {
+            method:'PUT',
+            headers:{'Authorization':`Bearer ${authToken}`,'Content-Type':'application/json'},
+            body: JSON.stringify(configData)
+        });
+        if(res.ok){
+            closeModal('createCaseModal');
+            loadAgents();
+        }else{
+            alert('Failed to create case');
+        }
+    }catch(err){
+        alert('Failed to create case');
     }
 }
 


### PR DESCRIPTION
## Summary
- allow admins to create a new case from the user page
- reuse admin modal styles for creating a case
- add JavaScript logic for submitting the new case

## Testing
- `pytest tests/` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b6616ff8c832e910b45881a792be3