### PR TITLE
Add agent delete feature

### DIFF
--- a/database.py
+++ b/database.py
@@ -207,6 +207,24 @@ def delete_uploaded_file_by_name(tenant: str, agent: str, filename: str) -> None
         con.commit()
 
 
+def delete_agent_data(tenant: str, agent: str) -> None:
+    """Delete all records related to an agent."""
+    with get_db() as con:
+        con.execute(
+            "DELETE FROM chat_logs WHERE tenant = ? AND agent = ?",
+            (tenant, agent),
+        )
+        con.execute(
+            "DELETE FROM uploaded_files WHERE tenant = ? AND agent = ?",
+            (tenant, agent),
+        )
+        con.execute(
+            "DELETE FROM llm_logs WHERE tenant = ? AND agent = ?",
+            (tenant, agent),
+        )
+        con.commit()
+
+
 def get_uploaded_file(file_id: int):
     """Get metadata for a single uploaded file"""
     with get_db() as con:

--- a/static/admin.html
+++ b/static/admin.html
@@ -325,6 +325,7 @@
             display: flex;
             gap: 8px;
             flex-wrap: wrap;
+            align-items: center;
         }
         
         .btn-small {
@@ -1191,6 +1192,7 @@
                                         <button class="btn btn-small btn-secondary" onclick="testAgent('${tenant.tenant}', '${agent}')">Test</button>
                                         <button class="btn btn-small btn-warning" onclick="uploadFiles('${tenant.tenant}', '${agent}')">Upload</button>
                                         <button class="btn btn-small btn-outline" onclick="getEmbedCode('${tenant.tenant}', '${agent}')">Embed</button>
+                                        <button class="btn btn-small btn-danger" onclick="deleteAgent('${tenant.tenant}', '${agent}')">Delete</button>
                                     </div>
                                 </div>
                             `).join('')}
@@ -1859,6 +1861,27 @@
                 }
             } catch (error) {
                 console.error('Failed to delete user:', error);
+            }
+        }
+
+        async function deleteAgent(tenant, agent) {
+            if (!confirm(`Are you sure you want to delete agent "${agent}"?`)) return;
+
+            try {
+                const response = await fetch(`${API_BASE}/agents/${tenant}/${agent}`, {
+                    method: 'DELETE',
+                    headers: { 'Authorization': `Bearer ${authToken}` }
+                });
+
+                if (response.ok) {
+                    loadTenants();
+                    showSuccess('Agent deleted successfully!');
+                } else {
+                    const err = await response.json();
+                    alert(err.detail || 'Failed to delete agent');
+                }
+            } catch (error) {
+                console.error('Failed to delete agent:', error);
             }
         }
 


### PR DESCRIPTION
## Summary
- enable deleting all agent data via `/agents/{tenant}/{agent}` API
- add helper in database to purge agent records
- update admin UI with Delete button for agents
- align agent action buttons horizontally

## Testing
- `python -m py_compile database.py routers/config_routes.py`

------
https://chatgpt.com/codex/tasks/task_e_685b7dc380c0832e930147be31923ec5