### PR TITLE
Improve user permission error feedback

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -183,7 +183,8 @@ async def get_admin_user(current_user: User = Depends(get_current_active_user)):
     """Get the current user if they are an admin"""
     if current_user.role not in ["admin", "system_admin"]:
         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions"
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Your permissions are not sufficient to complete this action",
         )
     return current_user
 
@@ -192,7 +193,8 @@ async def get_system_admin_user(current_user: User = Depends(get_current_active_
     """Ensure the user is a system administrator"""
     if current_user.role != "system_admin":
         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions"
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Your permissions are not sufficient to complete this action",
         )
     return current_user
 
@@ -204,7 +206,7 @@ async def get_files_user(current_user: User = Depends(get_current_active_user)):
     if not getattr(current_user, "allow_files", False):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Not enough permissions",
+            detail="Your permissions are not sufficient to complete this action",
         )
     return current_user
 

--- a/routers/auth_routes.py
+++ b/routers/auth_routes.py
@@ -66,12 +66,14 @@ async def create_new_user(user: UserCreate, admin: User = Depends(get_admin_user
     if admin.role == "system_admin":
         if user.role == "system_admin":
             raise HTTPException(
-                status_code=400, detail="Cannot create another system admin"
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Your permissions are not sufficient to complete this action",
             )
     else:
         if user.role != "user":
             raise HTTPException(
-                status_code=403, detail="Admins can only create regular users"
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Your permissions are not sufficient to complete this action",
             )
         user.tenant = admin.tenant
     if create_user(user):
@@ -93,7 +95,8 @@ async def update_existing_user(
         )
     if admin.role != "system_admin" and existing.tenant != admin.tenant:
         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions"
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Your permissions are not sufficient to complete this action",
         )
     if (
         "tenant" in user_data
@@ -101,7 +104,8 @@ async def update_existing_user(
         and user_data["tenant"] != admin.tenant
     ):
         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Cannot change tenant"
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Your permissions are not sufficient to complete this action",
         )
     if update_user(username, user_data):
         return {"message": "User updated successfully"}

--- a/routers/ingest_routes.py
+++ b/routers/ingest_routes.py
@@ -231,7 +231,10 @@ async def serve_uploaded_file(
 
     # Enforce file permissions similar to get_files_user
     if user.role not in ["admin", "system_admin"] and not getattr(user, "allow_files", False):
-        raise HTTPException(status_code=403, detail="Not enough permissions")
+        raise HTTPException(
+            status_code=403,
+            detail="Your permissions are not sufficient to complete this action",
+        )
 
     if user.tenant != "*" and user.tenant != tenant:
         raise HTTPException(status_code=403, detail="You don't have access to this tenant")

--- a/static/admin.html
+++ b/static/admin.html
@@ -1756,10 +1756,10 @@
                     e.target.reset();
                 } else {
                     const error = await response.json();
-                    showError('createUserError', error.detail || 'Failed to create user');
+                    showError('createUserError', error.detail || 'Your permissions are not sufficient to complete this action');
                 }
             } catch (error) {
-                showError('createUserError', 'Failed to create user');
+                showError('createUserError', 'Your permissions are not sufficient to complete this action');
             }
         }
 

--- a/static/user.html
+++ b/static/user.html
@@ -466,10 +466,10 @@ async function handleCreateUser(e){
             closeModal('createUserModal');
             e.target.reset();
         }else{
-            alert('Failed to create user');
+            alert('Your permissions are not sufficient to complete this action');
         }
     }catch(err){
-        alert('Failed to create user');
+        alert('Your permissions are not sufficient to complete this action');
     }
 }
 


### PR DESCRIPTION
## Summary
- generalize permission errors to state "Your permissions are not sufficient to complete this action"
- update admin/user web pages to show the same error message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7d46f3b8832e8416f187859b5850