### PR TITLE
Improve chat response formatting

### DIFF
--- a/static/chat.html
+++ b/static/chat.html
@@ -145,10 +145,17 @@ function renderHistory(){
     });
 }
 
+function formatMessage(text){
+    return text
+        .replace(/\*\*(.*?)\*\*/g,'<b>$1</b>')
+        .replace(/\s*([\-*\u2022]\s)/g,'<br>$1')
+        .replace(/\n/g,'<br>');
+}
+
 function addMessage(text,cls,sources=[]){
     const div=document.createElement('div');
     div.className='msg '+cls;
-    let html=text;
+    let html=cls==='bot'?formatMessage(text):text;
     if(cls==='bot' && sources && sources.length){
         sources.slice(0,6).forEach((s,i)=>{
             const link=formatSourceLink(s.source);


### PR DESCRIPTION
## Summary
- support bold text and line breaks before bullets in chat responses

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685cc37e4468832e8d51dc541defbce6