### PR TITLE
Add language field to user accounts

### DIFF
--- a/DATABASE_LAYOUT.md
+++ b/DATABASE_LAYOUT.md
@@ -47,8 +47,8 @@ exist an HTTP 404 error is raised until ingestion is performed.
 User accounts are stored in the JSON file `users.json` in the project root. The
 default file contains an `admin` account with the role `system_admin`.
 `auth.py` reads and writes this file when users are created or updated. Each
-record stores the username, tenant, role, assigned agents and a bcrypt-hashed
-password.
+record stores the username, tenant, role, assigned agents, preferred language
+and a bcrypt-hashed password.
 
 ## Tenants and Agents
 

--- a/auth.py
+++ b/auth.py
@@ -55,6 +55,7 @@ def get_users_db():
                 "role": "system_admin",
                 "agents": [],
                 "allow_files": True,
+                "language": "English",
                 "hashed_password": pwd_context.hash("admin"),
                 "disabled": False,
             }
@@ -145,7 +146,7 @@ def authenticate_aad_token(token: str):
     user = get_user(username)
     if user:
         return user
-    return User(username=username, tenant="*", role="user", agents=[])
+    return User(username=username, tenant="*", role="user", agents=[], language="English")
 
 
 async def get_current_user(token: str = Depends(oauth2_scheme)):
@@ -224,6 +225,7 @@ def create_user(user_data: UserCreate):
         "role": user_data.role,
         "agents": user_data.agents or [],
         "allow_files": user_data.allow_files,
+        "language": user_data.language,
         "disabled": user_data.disabled,
         "hashed_password": hashed_password,
     }

--- a/cli.py
+++ b/cli.py
@@ -168,7 +168,8 @@ def dashboard():
                     password=password,
                     tenant=tenant,
                     role=role,
-                    disabled=False
+                    disabled=False,
+                    language="English"
                 )
                 
                 if create_user(user_data):
@@ -351,7 +352,8 @@ def create_user_cli(
         password=password,
         tenant=tenant,
         role=role,
-        agents=agents or []
+        agents=agents or [],
+        language="English",
     )
     
     if create_user(user_data):

--- a/models.py
+++ b/models.py
@@ -13,6 +13,7 @@ class User(BaseModel):
     disabled: bool = False
     agents: Optional[List[str]] = []
     allow_files: bool = False
+    language: str = "English"
 
 
 class UserCreate(User):

--- a/users.json
+++ b/users.json
@@ -5,6 +5,7 @@
     "role": "system_admin",
     "agents": [],
     "allow_files": true,
+    "language": "English",
     "hashed_password": "$2b$12$QJJmC4jT9RriTGXB2J73S./R0DHYlFrjGt2fTObeuhFDGKwaPlOuy",
     "disabled": false
   }


### PR DESCRIPTION
## Summary
- include language field in `User` model and CLI commands
- store language in auth user database
- note language field in documentation

## Testing
- `python -m py_compile models.py auth.py cli.py`

------
https://chatgpt.com/codex/tasks/task_e_685cc518809c832ea696fe1129192437