### PR TITLE
Add language field for user creation

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -706,6 +706,15 @@
                         <option value="admin">Admin</option>
                     </select>
                 </div>
+                <div class="form-group">
+                    <label for="newUserLanguage">Language</label>
+                    <select id="newUserLanguage" name="language">
+                        <option value="English">English</option>
+                        <option value="Spanish">Spanish</option>
+                        <option value="French">French</option>
+                        <option value="German">German</option>
+                    </select>
+                </div>
                 <div class="checkbox-group">
                     <input type="checkbox" id="newUserFiles" name="allow_files">
                     <label for="newUserFiles">File Permissions</label>
@@ -1770,7 +1779,8 @@
                 agents: [formData.get('agent')],
                 role: formData.get('role'),
                 disabled: false,
-                allow_files: formData.get('allow_files') === 'on'
+                allow_files: formData.get('allow_files') === 'on',
+                language: formData.get('language')
             };
 
             try {

--- a/static/user.html
+++ b/static/user.html
@@ -198,6 +198,15 @@
                         <option value="admin">Admin</option>
                     </select>
                 </div>
+                <div class="form-group">
+                    <label for="newUserLanguage">Language</label>
+                    <select id="newUserLanguage" name="language">
+                        <option value="English">English</option>
+                        <option value="Spanish">Spanish</option>
+                        <option value="French">French</option>
+                        <option value="German">German</option>
+                    </select>
+                </div>
                 <div class="checkbox-group">
                     <input type="checkbox" id="newUserFiles" name="allow_files">
                     <label for="newUserFiles">File Permissions</label>
@@ -472,7 +481,8 @@ async function handleCreateUser(e){
         agents: [fd.get('agent')],
         role: fd.get('role'),
         disabled: false,
-        allow_files: fd.get('allow_files') === 'on'
+        allow_files: fd.get('allow_files') === 'on',
+        language: fd.get('language')
     };
     try{
         const res = await fetch(`${API_BASE}/users`, {


### PR DESCRIPTION
## Summary
- add language selector when creating users in admin and user pages
- include language in JavaScript user creation requests

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685cca5f9bbc832ea03aaefe17e14450