### PR TITLE
Add model and answer to LLM log view

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -1471,7 +1471,9 @@
                     <td>${log.status}</td>
                     <td>${log.tenant || ''}</td>
                     <td>${log.agent || ''}</td>
+                    <td>${log.model || ''}</td>
                     <td>${log.description ? log.description : (log.error ? 'error: ' + log.error : '')}</td>
+                    <td>${log.answer || ''}</td>
                 </tr>
             `).join('');
             return `
@@ -1484,7 +1486,9 @@
                                 <th>Status</th>
                                 <th>Tenant</th>
                                 <th>Agent</th>
+                                <th>Model</th>
                                 <th>Description</th>
+                                <th>Answer</th>
                             </tr>
                         </thead>
                         <tbody>${rows}</tbody>


### PR DESCRIPTION
## Summary
- extend `/llm_logs` endpoint to return model and answer
- show new columns in Settings -> LLM Logs table

## Testing
- `python -m py_compile routers/admin_routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68602701ae58832eb79fb1568bca6608