### PR TITLE
Fix loading of agent LLM config in admin UI

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -1602,8 +1602,8 @@
         // Agent configuration
         async function configureAgent(tenant, agent) {
             try {
-                // Load current configuration
-                const response = await fetch(`${API_BASE}/config?tenant=${tenant}&agent=${agent}`, {
+                // Load current configuration (full details)
+                const response = await fetch(`${API_BASE}/config/full?tenant=${tenant}&agent=${agent}`, {
                     headers: { 'Authorization': `Bearer ${authToken}` }
                 });
 


### PR DESCRIPTION
## Summary
- fetch the full agent configuration when opening the agent editor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860481e8448832eb9ff93f5e5be7ce5