### PR TITLE
Update chat font and icon reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ venv/
 *.pyc
 
 .env
+static/gavel-2-64.ico

--- a/static/chat.html
+++ b/static/chat.html
@@ -13,6 +13,7 @@
             --gray-700: #616161;
             --gray-800: #424242;
             --white: #ffffff;
+            --body-font-size: 16px;
         }
         html,body{
             height:100%;
@@ -22,6 +23,7 @@
             color:var(--gray-800);
             border:0.5in solid var(--gray-200);
             box-sizing:border-box;
+            font-size:var(--body-font-size);
         }
         #app{display:flex;height:100%;overflow:hidden;}
         #sidebar{width:260px;background:var(--white);border-right:1px solid var(--gray-200);display:flex;flex-direction:column;transition:transform .3s ease;}
@@ -77,7 +79,7 @@
         <div id="messages"></div>
         <form id="chatForm">
             <input id="chatInput" type="text" autocomplete="off" placeholder="Please ask your question...">
-            <button id="sendBtn" type="submit">Send</button>
+            <button id="sendBtn" type="submit"><img src="gavel-2-64.ico" alt="Send" style="width:20px;height:20px;"></button>
         </form>
     </div>
 </div>
@@ -88,6 +90,11 @@ const agent=params.get('agent')||'';
 const token=localStorage.getItem('rag_auth_token');
 const sessionId=sessionStorage.getItem('cq_sid')||Math.random().toString(36).slice(2);
 sessionStorage.setItem('cq_sid',sessionId);
+let bodyFontSize=parseInt(localStorage.getItem('body_font_size'))||16;
+function applyBodyFontSize(){
+    document.documentElement.style.setProperty('--body-font-size', bodyFontSize + 'px');
+}
+applyBodyFontSize();
 let sidebarVisible=false;
 let chatHistory=[];
 let filteredHistory=[];


### PR DESCRIPTION
## Summary
- apply configurable body font size from local storage in chat interface
- replace text on send button with gavel icon reference
- ignore icon file in repository

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'passlib')*

------
https://chatgpt.com/codex/tasks/task_e_68604afb74c8832eb75d0980c5ee7d08