### PR TITLE
Add formatting for quick-start guide

### DIFF
--- a/static/chat.html
+++ b/static/chat.html
@@ -92,13 +92,13 @@
         </form>
         <div id="guideOverlay" class="hidden">
             <div class="content">
-                Quick-Start Prompting Guide for your “Second Chair” Digital Navigator<br><br>
-                Talk to it like a colleague. Write a complete sentence or two—just as you’d brief your in-house legal analyst:<br>
-                “Under California contract law, is this 2-year, 10-mile non-compete for a physician enforceable? Give me a 3-paragraph memo with two on-point cases.”<br><br>
-                Give the essentials up front. Jurisdiction, key facts, and the exact output you want. The clearer the scene, the sharper the answer.<br><br>
-                One request at a time. Separate drafting tasks (“draft interrogatories”) from analysis tasks (“summarize deposition themes”) to avoid mixed results.<br><br>
-                Narrow the lane. If you don’t want antitrust angles, say so. Boundaries keep the AI from wandering.<br><br>
-                Iterate like draft reviews. Follow up with “Great—tighten the reasonableness analysis” instead of starting over.<br><br>
+                <u>Quick-Start Prompting Guide for your “Second Chair” Digital Navigator</u><br><br>
+                <b>Talk to it like a colleague.</b> Write a complete sentence or two—just as you’d brief your in-house legal analyst:<br>
+                <i>“Under California contract law, is this 2-year, 10-mile non-compete for a physician enforceable? Give me a 3-paragraph memo with two on-point cases.”</i><br><br>
+                <b>Give the essentials up front.</b> Jurisdiction, key facts, and the exact output you want. The clearer the scene, the sharper the answer.<br><br>
+                <b>One request at a time.</b> Separate drafting tasks (“draft interrogatories”) from analysis tasks (“summarize deposition themes”) to avoid mixed results.<br><br>
+                <b>Narrow the lane.</b> If you don’t want antitrust angles, say so. Boundaries keep the AI from wandering.<br><br>
+                <b>Iterate like draft reviews.</b> Follow up with “Great—tighten the reasonableness analysis” instead of starting over.<br><br>
                 Treat every prompt as a concise assignment memo, and your Digital Navigator will respond with work product that needs minimal polishing.
             </div>
         </div>


### PR DESCRIPTION
## Summary
- emphasize elements of the quick-start guide in `static/chat.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68606f3e14c8832eac41ab6e32cdc8d9