### PR TITLE
Fix returning to home page after login

### DIFF
--- a/static/user.html
+++ b/static/user.html
@@ -585,6 +585,16 @@ function showError(elementId, message) {
         alert(message);
     }
 }
+
+// Automatically validate an existing token on page load so that returning
+// users are taken directly to their home screen instead of the login form.
+document.addEventListener('DOMContentLoaded', () => {
+    if (authToken) {
+        validateToken();
+    } else {
+        showLoginPage();
+    }
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- automatically validate auth token when `user.html` loads so returning users see the home screen

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861c3f50a8c832ea9f483eeb40e5165