### PR TITLE
Fix chat border style

### DIFF
--- a/static/chat.html
+++ b/static/chat.html
@@ -13,7 +13,7 @@
             font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
             background:var(--gray-100);
             color:var(--gray-800);
-            border:0.5in solid var(--gray-200);
+            border:0.5in solid var(--black);
             box-sizing:border-box;
             font-size:var(--body-font-size);
         }

--- a/static/styles.css
+++ b/static/styles.css
@@ -9,6 +9,7 @@
     --gray-300: #bdbdbd;
     --gray-600: #757575;
     --gray-800: #424242;
+    --black: #000000;
     --white: #ffffff;
     --shadow: 0 2px 4px rgba(0,0,0,0.1);
     --shadow-lg: 0 4px 12px rgba(0,0,0,0.15);

--- a/static/user.html
+++ b/static/user.html
@@ -10,7 +10,7 @@
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body {
             font-family: 'Inter', sans-serif;
-            background: black;
+            background: var(--black);
             color: var(--gray-800);
             line-height: 1.6;
             font-size: var(--body-font-size);
@@ -24,7 +24,7 @@
             justify-content: center;
             align-items: center;
             min-height: 100vh;
-            background: #000;
+            background: var(--black);
         }
         .login-box {
             background: var(--white);


### PR DESCRIPTION
## Summary
- set new `--black` variable in stylesheet
- make chat page border black using the new variable
- reuse the variable in user page so borders match

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jose')*

------
https://chatgpt.com/codex/tasks/task_e_6861ca3275a0832e94301ac8b7c6bb00