### PR TITLE
Update send button style

### DIFF
--- a/static/chat.html
+++ b/static/chat.html
@@ -45,7 +45,18 @@
         form{display:flex;border-top:1px solid var(--gray-200);align-items:center;}
         #chatInput{flex:1;padding:32px 16px;border:none;font-size:16px;}
         #chatInput:focus{outline:none;}
-        #sendBtn{background:var(--primary);color:var(--white);border:none;padding:0 18px;cursor:pointer;transition:background .2s;}
+        #sendBtn{
+            background:var(--primary);
+            color:var(--white);
+            border:none;
+            width:80px;
+            height:40px;
+            display:flex;
+            align-items:center;
+            justify-content:center;
+            cursor:pointer;
+            transition:background .2s;
+        }
         #sendBtn:hover{background:var(--primary-dark);}
         #guideBtn{width:40px;height:40px;border-radius:50%;background:var(--primary);color:var(--white);border:none;display:flex;align-items:center;justify-content:center;font-size:24px;cursor:pointer;margin-left:8px;margin-right:8px;}
         #guideBtn:hover{background:var(--primary-dark);}


### PR DESCRIPTION
## Summary
- adjust chat send button CSS to match guide button height and double width
- ensure text centers in the button

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861eee781e4832eacab52ca5e18ce2d