### PR TITLE
Adjust chat window width when sidebar open

### DIFF
--- a/static/chat.html
+++ b/static/chat.html
@@ -31,7 +31,12 @@
         #chatList .title{font-weight:600;}
         #chatList .preview{font-size:12px;color:var(--gray-700);margin-top:4px;}
         #chatWindow{flex:1;display:flex;flex-direction:column;max-width:800px;margin:0 auto;background:var(--white);box-shadow:0 0 6px rgba(0,0,0,0.1);border-bottom:2px solid var(--gray-200);transition:transform .3s ease,max-width .3s ease;}
-        #chatWindow.shifted{transform:translateX(260px);}
+        #chatWindow.shifted{
+            margin-left:260px;
+            width:calc(100% - 260px);
+            max-width:calc(100% - 260px);
+            transform:none;
+        }
         #chatWindow.expanded{max-width:none;width:100%;}
         #chatHeader{display:flex;align-items:center;justify-content:space-between;padding:10px 15px;background:linear-gradient(90deg,var(--primary),var(--primary-dark));color:var(--white);}
         #toggleSidebar{background:none;border:none;color:var(--white);font-size:20px;cursor:pointer;}
@@ -67,8 +72,13 @@
         .btn{display:inline-block;padding:12px 24px;background:var(--primary);color:var(--white);border:none;border-radius:8px;cursor:pointer;font-size:14px;font-weight:600;transition:all .2s;text-align:center;}
         .btn:hover{background:var(--primary-dark);transform:translateY(-1px);}
         .btn-small{padding:6px 12px;font-size:12px;}
-        @media(max-width:768px){#chatWindow{max-width:none;width:100%;}
-        #chatWindow.shifted{transform:none;}}
+        @media(max-width:768px){
+            #chatWindow{max-width:none;width:100%;}
+            #chatWindow.shifted{
+                margin-left:260px;
+                width:calc(100% - 260px);
+            }
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- make the chat window shrink instead of translating when the sidebar is toggled
- keep the width responsive on small screens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68620171a760832e871ec0f5dbabd770