### PR TITLE
Fix chat replies language by detecting question language

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,6 @@ lxml>=4.9.0
 pytest>=7.4.0
 pytest-asyncio>=0.21.0
 httpx>=0.25.0
+
+# Language detection
+langdetect>=1.0.9


### PR DESCRIPTION
## Summary
- detect the language of user questions with `langdetect`
- instruct the bot to respond in that language
- add `langdetect` to requirements

## Testing
- `pip install langdetect==1.0.9`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68631c3b485c832ea95b5b372f663c5e