### PR TITLE
Add Node login app with MSAL

### DIFF
--- a/login-app/.env.example
+++ b/login-app/.env.example
@@ -1,0 +1,3 @@
+PORT=3000
+DATABASE_URL="file:./dev.db"
+JWT_SECRET="your-jwt-secret"

--- a/login-app/.eslintrc.cjs
+++ b/login-app/.eslintrc.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  env: { node: true, es2022: true },
+};

--- a/login-app/README.md
+++ b/login-app/README.md
@@ -1,0 +1,23 @@
+# Login App
+
+This directory contains a minimal Node.js/Express server with local and Microsoft Entra ID authentication. The front-end is a simple React page served at `/static/login.html`.
+
+## Setup
+
+1. **Create a Microsoft Entra app registration**
+   - Note the **Client ID**, **Tenant ID** and add a web redirect URI (e.g. `http://localhost:3000/static/login.html`).
+2. **Configure environment variables**
+   - Copy `.env.example` to `.env` and set `JWT_SECRET`, `DATABASE_URL` and `PORT`.
+   - Insert the Entra values into `static/login.html` (clientId, authority and redirectUri comments).
+3. **Install dependencies and run migrations**
+   ```bash
+   npm install
+   npx prisma migrate dev --name init
+   npm run dev
+   ```
+4. **Optional: seed a local user**
+   ```bash
+   npm run seed
+   ```
+
+The application serves `static/login.html`. After signing in with Microsoft you will be redirected to `user.html`. Local sign‑in stores a `session` cookie and allows access to `/dashboard`.

--- a/login-app/package.json
+++ b/login-app/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "login-app",
+  "version": "1.0.0",
+  "type": "module",
+  "engines": {
+    "node": "20.x"
+  },
+  "scripts": {
+    "dev": "ts-node-dev --respawn src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "seed": "ts-node src/seed.ts",
+    "lint": "eslint . --ext .ts",
+    "format": "prettier --write ."
+  },
+  "dependencies": {
+    "@prisma/client": "^5.14.0",
+    "bcrypt": "^5.1.0",
+    "cookie-parser": "^1.4.6",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "helmet": "^7.0.0",
+    "jsonwebtoken": "^9.0.0",
+    "passport": "^0.6.0",
+    "passport-local": "^1.0.0"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^6.5.0",
+    "@typescript-eslint/parser": "^6.5.0",
+    "eslint": "^8.55.0",
+    "eslint-config-prettier": "^9.0.0",
+    "prettier": "^3.0.0",
+    "prisma": "^5.14.0",
+    "ts-node": "^10.9.1",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.2.2"
+  }
+}

--- a/login-app/prettier.config.cjs
+++ b/login-app/prettier.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  semi: true,
+  singleQuote: true,
+  trailingComma: 'all',
+};

--- a/login-app/prisma/schema.prisma
+++ b/login-app/prisma/schema.prisma
@@ -1,0 +1,17 @@
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id           Int      @id @default(autoincrement())
+  email        String   @unique
+  passwordHash String
+  provider     String
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+}

--- a/login-app/src/auth/jwt.ts
+++ b/login-app/src/auth/jwt.ts
@@ -1,0 +1,15 @@
+import jwt from 'jsonwebtoken';
+
+export function signToken(userId: number): string {
+  return jwt.sign({ sub: userId }, process.env.JWT_SECRET as string, {
+    expiresIn: '1h',
+  });
+}
+
+export function verifyToken(token: string): { sub: number } | null {
+  try {
+    return jwt.verify(token, process.env.JWT_SECRET as string) as { sub: number };
+  } catch {
+    return null;
+  }
+}

--- a/login-app/src/auth/passport.ts
+++ b/login-app/src/auth/passport.ts
@@ -1,0 +1,20 @@
+import passport from 'passport';
+import { Strategy as LocalStrategy } from 'passport-local';
+import bcrypt from 'bcrypt';
+import prisma from '../prisma';
+
+passport.use(
+  new LocalStrategy({ usernameField: 'email' }, async (email, password, done) => {
+    try {
+      const user = await prisma.user.findUnique({ where: { email } });
+      if (!user) return done(null, false);
+      const match = await bcrypt.compare(password, user.passwordHash);
+      if (!match) return done(null, false);
+      return done(null, user);
+    } catch (err) {
+      return done(err as Error);
+    }
+  }),
+);
+
+export default passport;

--- a/login-app/src/index.ts
+++ b/login-app/src/index.ts
@@ -1,0 +1,29 @@
+import express from 'express';
+import helmet from 'helmet';
+import cors from 'cors';
+import cookieParser from 'cookie-parser';
+import dotenv from 'dotenv';
+import path from 'path';
+import passport from './auth/passport';
+import authRoutes from './routes/auth';
+import protectedRoutes from './routes/protected';
+
+dotenv.config();
+
+const app = express();
+app.use(helmet());
+app.use(cors({ origin: true, credentials: true }));
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(cookieParser());
+app.use(passport.initialize());
+
+app.use('/api/auth', authRoutes);
+app.use('/api', protectedRoutes);
+
+app.use('/static', express.static(path.join(__dirname, '../static')));
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/login-app/src/middleware/requireAuth.ts
+++ b/login-app/src/middleware/requireAuth.ts
@@ -1,0 +1,27 @@
+import { Request, Response, NextFunction } from 'express';
+import prisma from '../prisma';
+import { verifyToken } from '../auth/jwt';
+
+export async function requireAuth(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  const token = req.cookies.session;
+  if (!token) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+  const payload = verifyToken(token);
+  if (!payload) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+  const user = await prisma.user.findUnique({ where: { id: payload.sub } });
+  if (!user) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+  (req as any).user = user;
+  next();
+}

--- a/login-app/src/prisma.ts
+++ b/login-app/src/prisma.ts
@@ -1,0 +1,4 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+export default prisma;

--- a/login-app/src/routes/auth.ts
+++ b/login-app/src/routes/auth.ts
@@ -1,0 +1,34 @@
+import { Router } from 'express';
+import passport from '../auth/passport';
+import { signToken, verifyToken } from '../auth/jwt';
+import prisma from '../prisma';
+
+const router = Router();
+
+router.post('/local', passport.authenticate('local', { session: false }), async (req, res) => {
+  const user = req.user as { id: number };
+  const token = signToken(user.id);
+  res.cookie('session', token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+  });
+  res.json({ ok: true });
+});
+
+router.post('/logout', (req, res) => {
+  res.clearCookie('session');
+  res.json({ ok: true });
+});
+
+router.get('/me', async (req, res) => {
+  const token = req.cookies.session;
+  if (!token) return res.status(401).json({ error: 'Unauthorized' });
+  const payload = verifyToken(token);
+  if (!payload) return res.status(401).json({ error: 'Unauthorized' });
+  const user = await prisma.user.findUnique({ where: { id: payload.sub } });
+  if (!user) return res.status(401).json({ error: 'Unauthorized' });
+  res.json({ id: user.id, email: user.email });
+});
+
+export default router;

--- a/login-app/src/routes/protected.ts
+++ b/login-app/src/routes/protected.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { requireAuth } from '../middleware/requireAuth';
+
+const router = Router();
+
+router.get('/dashboard-data', requireAuth, (req, res) => {
+  res.json({ message: 'Protected content' });
+});
+
+export default router;

--- a/login-app/src/seed.ts
+++ b/login-app/src/seed.ts
@@ -1,0 +1,16 @@
+import bcrypt from 'bcrypt';
+import prisma from './prisma';
+
+async function main() {
+  const passwordHash = await bcrypt.hash('password', 12);
+  await prisma.user.create({
+    data: { email: 'user@example.com', passwordHash, provider: 'local' },
+  });
+  console.log('Seed user created');
+}
+
+main()
+  .catch((e) => console.error(e))
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/login-app/tsconfig.json
+++ b/login-app/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/static/admin.html
+++ b/static/admin.html
@@ -1153,7 +1153,7 @@
             const formData = new FormData(e.target);
             
             try {
-                const response = await fetch(`${API_BASE}/token`, {
+                const response = await fetch('/api/auth/local', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/x-www-form-urlencoded',

--- a/static/login.css
+++ b/static/login.css
@@ -1,0 +1,36 @@
+body {
+  background: var(--gray-100);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+}
+
+#login-root {
+  background: var(--white);
+  padding: 2rem;
+  border-radius: 0.5rem;
+  box-shadow: var(--shadow-lg);
+  width: 100%;
+  max-width: 600px;
+}
+
+.btn {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  background: var(--primary);
+  color: var(--white);
+  border-radius: 0.25rem;
+  text-align: center;
+  cursor: pointer;
+  border: none;
+}
+
+.btn:hover {
+  background: var(--primary-dark);
+}
+
+.btn-full {
+  width: 100%;
+}

--- a/static/login.html
+++ b/static/login.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Login</title>
+  <link rel="stylesheet" href="/static/styles.css" />
+  <link rel="stylesheet" href="/static/login.css" />
+</head>
+<body>
+  <div id="login-root"></div>
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="https://unpkg.com/@azure/msal-browser/dist/msal-browser.min.js"></script>
+  <script src="https://unpkg.com/@azure/msal-react/dist/msal-react.umd.js"></script>
+  <script src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.production.min.js"></script>
+  <script type="text/javascript">
+    const {PublicClientApplication} = msal;
+    const msalConfig = {
+      auth: {
+        clientId: 'YOUR_CLIENT_ID', // TODO: Insert Microsoft Entra clientId
+        authority: 'https://login.microsoftonline.com/YOUR_TENANT_ID', // TODO: Insert authority
+        redirectUri: 'http://localhost:3000/static/login.html' // TODO: Insert redirectUri
+      }
+    };
+    const msalInstance = new PublicClientApplication(msalConfig);
+    msalInstance.handleRedirectPromise().then(result => {
+      if (result) window.location.href = '/static/user.html';
+    });
+    const {BrowserRouter,Routes,Route,Navigate} = ReactRouterDOM;
+    const {MsalProvider,useIsAuthenticated} = msalReact;
+
+    const useAuth = () => {
+      const [user,setUser] = React.useState(null);
+      React.useEffect(()=>{
+        fetch('/api/auth/me',{credentials:'include'})
+          .then(r=>r.ok?r.json():null)
+          .then(d=>setUser(d));
+      },[]);
+      return user;
+    };
+
+    const LoginForm = () => {
+      const [error,setError]=React.useState('');
+      const onSubmit=async e=>{
+        e.preventDefault();
+        setError('');
+        const fd=new FormData(e.target);
+        const res = await fetch('/api/auth/local', {
+          method:'POST',
+          headers:{'Content-Type':'application/x-www-form-urlencoded'},
+          body:new URLSearchParams(fd),
+          credentials:'include'
+        });
+        if(res.ok){window.location='/dashboard';} else {setError('Invalid credentials');}
+      };
+      return React.createElement('form',{onSubmit,className:'space-y-4'},[
+        React.createElement('input',{className:'border p-2 w-full',name:'email',type:'email',placeholder:'Email',required:true}),
+        React.createElement('input',{className:'border p-2 w-full',name:'password',type:'password',placeholder:'Password',required:true}),
+        React.createElement('button',{className:'btn btn-full',type:'submit'},'Sign in'),
+        error?React.createElement('div',{className:'text-red-600'},error):null
+      ]);
+    };
+
+    const MicrosoftLogin = () => {
+      const login = ()=>msalInstance.loginRedirect({scopes:['user.read']});
+      return React.createElement('button',{className:'btn btn-full',onClick:login},'Sign in with Microsoft');
+    };
+
+    const LoginPage = () => React.createElement('div',null,[
+      React.createElement('h2',{className:'text-center mb-4'},'Sign In'),
+      React.createElement('div',{className:'flex gap-4'},[
+        React.createElement('div',{className:'w-1/2'},React.createElement(MicrosoftLogin)),
+        React.createElement('div',{className:'w-1/2'},React.createElement(LoginForm))
+      ])
+    ]);
+
+    const Dashboard = () => {
+      const user = useAuth();
+      const isMsal = useIsAuthenticated();
+      if(!user && !isMsal) return React.createElement(Navigate,{to:'/'})
+      const logout = () => {
+        fetch('/api/auth/logout',{method:'POST',credentials:'include'}).then(()=>{
+          msalInstance.logoutRedirect();
+        });
+      };
+      return React.createElement('div',null,[
+        React.createElement('h2',null,'Dashboard'),
+        React.createElement('button',{className:'btn',onClick:logout},'Logout')
+      ]);
+    };
+
+    const App = () => React.createElement(MsalProvider,{instance:msalInstance},
+      React.createElement(BrowserRouter,null,
+        React.createElement(Routes,null,[
+          React.createElement(Route,{path:'/',element:React.createElement(LoginPage)}),
+          React.createElement(Route,{path:'/dashboard',element:React.createElement(Dashboard)})
+        ])
+      )
+    );
+
+    ReactDOM.createRoot(document.getElementById('login-root')).render(React.createElement(App));
+  </script>
+</body>
+</html>

--- a/static/user.html
+++ b/static/user.html
@@ -333,7 +333,7 @@ async function handleLogin(e){
 
     const fd = new FormData(e.target);
     try{
-        const res = await fetch(`${API_BASE}/token`, {
+        const res = await fetch('/api/auth/local', {
             method:'POST',
             headers:{'Content-Type':'application/x-www-form-urlencoded'},
             body:`username=${encodeURIComponent(fd.get('username'))}&password=${encodeURIComponent(fd.get('password'))}`


### PR DESCRIPTION
## Summary
- create a `login-app` folder with an Express + TypeScript server
- add Prisma schema and auth implementation using passport-local
- add React-based `login.html` and CSS
- update `admin.html` and `user.html` to use new local login endpoint

## Testing
- `apt-get update && apt-get install -y tree`
- `tree -L 2`


------
https://chatgpt.com/codex/tasks/task_e_686c3221deb4832ea1e01f5ffcb845de