### PR TITLE
Fix login forms to use email

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -494,8 +494,8 @@
             <h2>Second Chair Login</h2>
             <form id="loginForm">
                 <div class="form-group">
-                    <label for="username">Username</label>
-                    <input type="text" id="username" name="username" required>
+                    <label for="email">Email</label>
+                    <input type="email" id="email" name="email" required>
                 </div>
                 <div class="form-group">
                     <label for="password">Password</label>
@@ -1158,7 +1158,7 @@
                     headers: {
                         'Content-Type': 'application/x-www-form-urlencoded',
                     },
-                    body: `username=${encodeURIComponent(formData.get('username'))}&password=${encodeURIComponent(formData.get('password'))}`
+                    body: `email=${encodeURIComponent(formData.get('email'))}&password=${encodeURIComponent(formData.get('password'))}`
                 });
 
                 if (response.ok) {
@@ -1168,7 +1168,7 @@
                     await loadUser();
                     showMainInterface();
                 } else {
-                    showError('loginError', 'Invalid username or password');
+                    showError('loginError', 'Invalid email or password');
                 }
             } catch (error) {
                 showError('loginError', 'Login failed. Please try again.');

--- a/static/user.html
+++ b/static/user.html
@@ -144,8 +144,8 @@
             <h2>Second Chair Login</h2>
             <form id="loginForm">
                 <div class="form-group">
-                    <label for="username">Username</label>
-                    <input type="text" id="username" name="username" required>
+                    <label for="email">Email</label>
+                    <input type="email" id="email" name="email" required>
                 </div>
                 <div class="form-group">
                     <label for="password">Password</label>
@@ -336,7 +336,7 @@ async function handleLogin(e){
         const res = await fetch('/api/auth/local', {
             method:'POST',
             headers:{'Content-Type':'application/x-www-form-urlencoded'},
-            body:`username=${encodeURIComponent(fd.get('username'))}&password=${encodeURIComponent(fd.get('password'))}`
+            body:`email=${encodeURIComponent(fd.get('email'))}&password=${encodeURIComponent(fd.get('password'))}`
         });
         if(res.ok){
             const data = await res.json();
@@ -345,7 +345,7 @@ async function handleLogin(e){
             await loadUser();
             showAgentPage();
         } else {
-            showError('loginError', 'Invalid username or password');
+            showError('loginError', 'Invalid email or password');
         }
     } catch(err){
         showError('loginError', 'Login failed. Please try again.');


### PR DESCRIPTION
## Summary
- update user and admin login forms to use email instead of username
- adjust login scripts accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68715d53ebdc832e80fa8ed732fd1c45