### PR TITLE
Add citation context with headings and lines

### DIFF
--- a/docs/file-checker.md
+++ b/docs/file-checker.md
@@ -101,13 +101,12 @@ Files are broken into chunks before embedding:
 # utils/file_processors.py
 
 # Import here to avoid circular dependency
-from ..vectorstore import chunk_text
+from ..utils.file_processors import _chunk_text_with_lines
 
-# Chunk the text
-chunks = chunk_text(raw_text)
-
-# Create metadata for each chunk
-metadatas = [{"source": filename} for _ in chunks]
+# Chunk the text with line metadata
+chunks, metadatas = _chunk_text_with_lines(raw_text)
+for m in metadatas:
+    m["source"] = filename
 ```
 
 ## 3. Background File Checker

--- a/routers/chat_routes.py
+++ b/routers/chat_routes.py
@@ -96,10 +96,17 @@ async def chat(
     # Extract sources
     sources, seen = [], set()
     for _, metadata, _ in search_results:
-        s = metadata.get("source", "")
-        if s and s not in seen:
-            sources.append({"source": s})
-            seen.add(s)
+        key = (metadata.get("source"), metadata.get("page"), metadata.get("line"))
+        if key[0] and key not in seen:
+            citation = {"source": key[0]}
+            if key[1] is not None:
+                citation["page"] = key[1]
+            if key[2] is not None:
+                citation["line"] = key[2]
+            if metadata.get("heading"):
+                citation["heading"] = metadata["heading"]
+            sources.append(citation)
+            seen.add(key)
     
     # Log the interaction
     log_chat(

--- a/tests/test_file_processors.py
+++ b/tests/test_file_processors.py
@@ -1,0 +1,16 @@
+import types
+import importlib.util
+
+spec = importlib.util.spec_from_file_location('utils.file_processors', 'utils/file_processors.py')
+file_proc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(file_proc)
+
+
+def test_chunk_text_with_lines():
+    text = "# Heading\nline1\nline2\nline3\nline4"
+    chunks, metas = file_proc._chunk_text_with_lines(text, lines_per_chunk=2)
+    assert chunks[0].startswith("# Heading") or chunks[0].startswith("line1")
+    assert metas[0]['line'] == 1
+    assert metas[0]['heading'] == 'Heading'
+    assert metas[1]['line'] == 3
+


### PR DESCRIPTION
## Summary
- extend file processing to include line numbers, section headings, and page info
- update chat route to return richer citation metadata
- document new chunking in the file checker guide
- add tests for chunking helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68786619d3fc832eb4e001847b5a773c