### PR TITLE
Allow username login

### DIFF
--- a/static/user.html
+++ b/static/user.html
@@ -145,8 +145,8 @@
             <h2>Second Chair Login</h2>
             <form id="loginForm">
                 <div class="form-group">
-                    <label for="email">Email</label>
-                    <input type="email" id="email" name="email" required>
+                    <label for="username">Username</label>
+                    <input type="text" id="username" name="username" required>
                 </div>
                 <div class="form-group">
                     <label for="password">Password</label>
@@ -347,7 +347,7 @@ async function handleLogin(e){
         const res = await fetch('/token', {
             method:'POST',
             headers:{'Content-Type':'application/x-www-form-urlencoded'},
-            body:`username=${encodeURIComponent(fd.get('email'))}&password=${encodeURIComponent(fd.get('password'))}`
+            body:`username=${encodeURIComponent(fd.get('username'))}&password=${encodeURIComponent(fd.get('password'))}`
         });
         if(res.ok){
             const data = await res.json();
@@ -356,7 +356,7 @@ async function handleLogin(e){
             await loadUser();
             showAgentPage();
         } else {
-            showError('loginError', 'Invalid email or password');
+            showError('loginError', 'Invalid username or password');
         }
     } catch(err){
         showError('loginError', 'Login failed. Please try again.');


### PR DESCRIPTION
## Summary
- allow username-based login in static user page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68786cc32818832ebc54b4755fab853e