### PR TITLE
Fix user login when MSAL script fails

### DIFF
--- a/static/user.html
+++ b/static/user.html
@@ -276,7 +276,14 @@ const msalConfig = {
         redirectUri: window.location.href
     }
 };
-const msalInstance = new msal.PublicClientApplication(msalConfig);
+let msalInstance = null;
+if (window.msal && window.msal.PublicClientApplication) {
+    msalInstance = new msal.PublicClientApplication(msalConfig);
+} else {
+    console.warn('MSAL library not loaded; Microsoft login disabled.');
+    const msBtn = document.getElementById('msLoginBtn');
+    if (msBtn) msBtn.style.display = 'none';
+}
 const styleDefaults={
     primary:"#1E88E5",
     primaryDark:"#1976D2",
@@ -366,6 +373,10 @@ async function handleLogin(e){
 }
 
 async function handleMicrosoftLogin(){
+    if(!msalInstance){
+        showError('loginError', 'Microsoft login not available');
+        return;
+    }
     const spinner = document.getElementById('loginSpinner');
     const errorDiv = document.getElementById('loginError');
     spinner.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- guard against missing MSAL library in `static/user.html`
- disable Microsoft login button if MSAL didn't load
- show helpful error if Microsoft login attempted without MSAL

## Testing
- `pip install bs4`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68786e96868c832e9e1676dd4c4c701a