### PR TITLE
Add citation context with headings and lines

### DIFF
--- a/docs/file-checker.md
+++ b/docs/file-checker.md
@@ -101,13 +101,12 @@ Files are broken into chunks before embedding:
 # utils/file_processors.py
 
 # Import here to avoid circular dependency
-from ..vectorstore import chunk_text
+from ..utils.file_processors import _chunk_text_with_lines
 
-# Chunk the text
-chunks = chunk_text(raw_text)
-
-# Create metadata for each chunk
-metadatas = [{"source": filename} for _ in chunks]
+# Chunk the text with line metadata
+chunks, metadatas = _chunk_text_with_lines(raw_text)
+for m in metadatas:
+    m["source"] = filename
 ```
 
 ## 3. Background File Checker

--- a/routers/chat_routes.py
+++ b/routers/chat_routes.py
@@ -96,10 +96,17 @@ async def chat(
     # Extract sources
     sources, seen = [], set()
     for _, metadata, _ in search_results:
-        s = metadata.get("source", "")
-        if s and s not in seen:
-            sources.append({"source": s})
-            seen.add(s)
+        key = (metadata.get("source"), metadata.get("page"), metadata.get("line"))
+        if key[0] and key not in seen:
+            citation = {"source": key[0]}
+            if key[1] is not None:
+                citation["page"] = key[1]
+            if key[2] is not None:
+                citation["line"] = key[2]
+            if metadata.get("heading"):
+                citation["heading"] = metadata["heading"]
+            sources.append(citation)
+            seen.add(key)
     
     # Log the interaction
     log_chat(

--- a/static/chat.html
+++ b/static/chat.html
@@ -47,6 +47,7 @@
         .cite-num{margin-left:4px;font-size:12px;text-decoration:none;}
         .cite-window{margin-top:4px;font-size:12px;display:flex;align-items:center;gap:6px;}
         .cite-window span{cursor:pointer;user-select:none;}
+        .cite-heading{font-style:italic;margin-left:4px;}
         form{display:flex;border-top:1px solid var(--gray-200);align-items:center;}
         #chatInput{flex:1;padding:32px 16px;border:none;font-size:16px;}
         #chatInput:focus{outline:none;}
@@ -242,7 +243,8 @@ function addMessage(text,cls,sources=[]){
     if(cls==='bot' && sources && sources.length){
         sources.slice(0,6).forEach((s,i)=>{
             const link=formatSourceLink(s.source);
-            html+=` <a href="${link}" target="_blank" class="cite-num" title="${s.source}">${circledNums[i]}</a>`;
+            const tip=[s.heading||'',s.page?`p.${s.page}`:'',s.line?`l.${s.line}`:'',s.source].filter(Boolean).join(' - ');
+            html+=` <a href="${link}" target="_blank" class="cite-num" title="${tip}">${circledNums[i]}</a>`;
         });
     }
     div.innerHTML=html;
@@ -250,11 +252,12 @@ function addMessage(text,cls,sources=[]){
         const cite=document.createElement('div');
         cite.className='cite-window';
         let idx=0;
-        cite.innerHTML=`Where did this answer come from? ${sources.length>1?'<span class="cite-prev">&#8592;</span>':''}<a class="cite-link" href="${formatSourceLink(sources[0].source)}" target="_blank">${sources[0].source}</a>${sources.length>1?'<span class="cite-next">&#8594;</span>':''}`;
+        cite.innerHTML=`Where did this answer come from? ${sources.length>1?'<span class="cite-prev">&#8592;</span>':''}<a class="cite-link" href="${formatSourceLink(sources[0].source)}" target="_blank">${sources[0].source}</a><span class="cite-heading">${sources[0].heading||''}</span>${sources.length>1?'<span class="cite-next">&#8594;</span>':''}`;
         const update=()=>{
             const src=sources[idx];
             cite.querySelector('.cite-link').href=formatSourceLink(src.source);
             cite.querySelector('.cite-link').textContent=src.source;
+            cite.querySelector('.cite-heading').textContent=src.heading||'';
         };
         if(sources.length>1){
             cite.querySelector('.cite-prev').addEventListener('click',()=>{idx=(idx-1+sources.length)%sources.length;update();});

--- a/tests/test_file_processors.py
+++ b/tests/test_file_processors.py
@@ -1,0 +1,16 @@
+import types
+import importlib.util
+
+spec = importlib.util.spec_from_file_location('utils.file_processors', 'utils/file_processors.py')
+file_proc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(file_proc)
+
+
+def test_chunk_text_with_lines():
+    text = "# Heading\nline1\nline2\nline3\nline4"
+    chunks, metas = file_proc._chunk_text_with_lines(text, lines_per_chunk=2)
+    assert chunks[0].startswith("# Heading") or chunks[0].startswith("line1")
+    assert metas[0]['line'] == 1
+    assert metas[0]['heading'] == 'Heading'
+    assert metas[1]['line'] == 3
+


### PR DESCRIPTION
## Summary
- extend file processing to include line numbers, section headings, and page info
- update chat route to return richer citation metadata
- document new chunking in the file checker guide
- add tests for chunking helper
- show headings on citation hover text and in "Where did this answer come from?" window

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68786619d3fc832eb4e001847b5a773c