### PR TITLE
Make citation line horizontal

### DIFF
--- a/static/chat.html
+++ b/static/chat.html
@@ -45,7 +45,7 @@
         .user{background:var(--primary);color:var(--white);margin-left:auto;}
         .bot{background:var(--gray-200);color:var(--gray-800);margin-right:auto;}
         .cite-num{margin-left:4px;font-size:12px;text-decoration:none;}
-        .cite-window{margin-top:4px;font-size:1em;display:flex;flex-direction:column;align-items:flex-start;gap:2px;}
+        .cite-window{margin-top:4px;font-size:1em;display:flex;flex-direction:row;align-items:center;gap:2px;}
         .cite-detail{font-style:italic;}
         .cite-window span{cursor:pointer;user-select:none;}
         form{display:flex;border-top:1px solid var(--gray-200);align-items:center;}
@@ -253,7 +253,7 @@ function addMessage(text,cls,sources=[]){
         cite.className='cite-window';
         let idx=0;
         const detailLink=sources[0].page?`<a href="${formatSourceLink(sources[0].source)}#page=${sources[0].page}" target="_blank">Page ${sources[0].page}</a>`:'';
-        cite.innerHTML=`Sources: ${sources.length>1?'<span class="cite-prev">&#8592;</span>':''}<a class="cite-link" href="${formatSourceLink(sources[0].source)}" target="_blank">${sources[0].source}</a>${sources.length>1?'<span class="cite-next">&#8594;</span>':''}<div class="cite-detail">${detailLink}${sources[0].heading?` - ${sources[0].heading}`:''}</div>`;
+        cite.innerHTML=`Sources: ${sources.length>1?'<span class="cite-prev">&#8592;</span>':''}<a class="cite-link" href="${formatSourceLink(sources[0].source)}" target="_blank">${sources[0].source}</a>${sources.length>1?'<span class="cite-next">&#8594;</span>':''}<span class="cite-detail">${detailLink}${sources[0].heading?` - ${sources[0].heading}`:''}</span>`;
         const update=()=>{
             const src=sources[idx];
             cite.querySelector('.cite-link').href=formatSourceLink(src.source);

--- a/widget.py
+++ b/widget.py
@@ -220,7 +220,7 @@ function addMessage(role, content, sources = []) {{
     const citeDiv = document.createElement('div');
     citeDiv.className = 'cq-cite-window';
     let idx = 0;
-    citeDiv.innerHTML = `${{sources.length > 1 ? '<span class="cq-prev">←</span>' : ''}}<a class="cq-citation-link" href="${{sources[0].source}}" target="_blank">${{sources[0].source}}</a>${{sources.length > 1 ? '<span class="cq-next">→</span>' : ''}}<div class="cq-detail">${{sources[0].page ? `Page ${sources[0].page}` : ''}}{{sources[0].heading ? ` - ${sources[0].heading}` : ''}}</div>`;
+    citeDiv.innerHTML = `${{sources.length > 1 ? '<span class="cq-prev">←</span>' : ''}}<a class="cq-citation-link" href="${{sources[0].source}}" target="_blank">${{sources[0].source}}</a>${{sources.length > 1 ? '<span class="cq-next">→</span>' : ''}}<span class="cq-detail">${{sources[0].page ? `Page ${sources[0].page}` : ''}}{{sources[0].heading ? ` - ${sources[0].heading}` : ''}}</span>`;
     const updateCitation = () => {{
       const src = sources[idx];
       citeDiv.querySelector('a').href = src.source;
@@ -706,8 +706,8 @@ def generate_widget_css(config):
     margin-top: 4px;
     font-size: 1em;
     display: flex;
-    flex-direction: column;
-    align-items: flex-start;
+    flex-direction: row;
+    align-items: center;
     gap: 2px;
   }}
 


### PR DESCRIPTION
## Summary
- show citation elements on one line
- keep widget styling in sync

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bf9343ea4832e81cf1c46870ca6cb