### PR TITLE
Add templates dropdown menu

### DIFF
--- a/static/chat.html
+++ b/static/chat.html
@@ -40,6 +40,14 @@
         #chatWindow.expanded{max-width:none;width:100%;}
         #chatHeader{display:flex;align-items:center;justify-content:space-between;padding:10px 15px;background:linear-gradient(90deg,var(--primary),var(--primary-dark));color:var(--white);}
         #toggleSidebar{background:none;border:none;color:var(--white);font-size:20px;cursor:pointer;}
+        #headerLeft{display:flex;align-items:center;gap:8px;}
+        #templatesContainer{position:relative;}
+        #templatesBtn{background:var(--primary);color:var(--white);border:none;padding:6px 12px;border-radius:6px;cursor:pointer;font-size:14px;}
+        #templatesBtn:hover{background:var(--primary-dark);}
+        #templatesDropdown{position:absolute;top:100%;left:0;background:var(--white);color:var(--gray-800);border:1px solid var(--gray-200);border-radius:6px;box-shadow:var(--shadow);min-width:180px;display:none;flex-direction:column;z-index:100;}
+        #templatesDropdown.show{display:flex;}
+        #templatesDropdown div{padding:8px 12px;cursor:pointer;white-space:nowrap;}
+        #templatesDropdown div:hover{background:var(--gray-100);}
         #messages{flex:1;overflow-y:auto;padding:15px;}
         .msg{max-width:80%;margin-bottom:12px;padding:10px 14px;border-radius:10px;line-height:1.4;}
         .user{background:var(--primary);color:var(--white);margin-left:auto;}
@@ -94,7 +102,18 @@
     </div>
     <div id="chatWindow">
         <div id="chatHeader">
-            <button id="toggleSidebar">☰</button>
+            <div id="headerLeft">
+                <button id="toggleSidebar">☰</button>
+                <div id="templatesContainer">
+                    <button id="templatesBtn" type="button">Templates ▾</button>
+                    <div id="templatesDropdown">
+                        <div class="template-option">Deposition Summary</div>
+                        <div class="template-option">Case Brief</div>
+                        <div class="template-option">Chronology</div>
+                        <div class="template-option">Motion outline (Memo of Points & Authority)</div>
+                    </div>
+                </div>
+            </div>
             <span id="chatTitle">Chat</span>
             <button id="homeBtn" class="btn btn-small">Home</button>
         </div>
@@ -334,6 +353,13 @@ document.getElementById('guideBtn').addEventListener('click',()=>{
 document.getElementById('guideOverlay').addEventListener('click',()=>{
     document.getElementById('guideOverlay').classList.add('hidden');
 });
+
+const templatesBtn=document.getElementById('templatesBtn');
+const templatesDropdown=document.getElementById('templatesDropdown');
+const templatesContainer=document.getElementById('templatesContainer');
+templatesBtn.addEventListener('click',e=>{e.stopPropagation();templatesDropdown.classList.toggle('show');});
+document.addEventListener('click',e=>{if(!templatesContainer.contains(e.target))templatesDropdown.classList.remove('show');});
+document.querySelectorAll('.template-option').forEach(o=>o.addEventListener('click',()=>{document.getElementById('chatInput').value=o.textContent;templatesDropdown.classList.remove('show');}));
 
 loadHistory();
 </script>


### PR DESCRIPTION
## Summary
- add a Templates dropdown next to hamburger menu in `chat.html`
- populate dropdown with four template options
- allow selecting an option to fill the input box

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688553042cc8832ea3d3e53a2a5ddd9e