### PR TITLE
Improve ingestion with OCR fallback

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,8 @@ python-docx>=1.1.0
 python-pptx>=0.6.23
 openpyxl>=3.1.2
 beautifulsoup4>=4.12.0
+pdf2image>=1.17.0
+pytesseract>=0.3.10
 
 # Google Drive integration
 google-auth>=2.25.0


### PR DESCRIPTION
## Summary
- update `utils.file_processors` to OCR PDF pages without text
- track OCR use in the database with new `ocr_used` column
- expose OCR info through ingestion API
- update uploaded files endpoint to show OCR usage
- include pdf2image and pytesseract dependencies

## Testing
- `pip install -q pdf2image pytesseract`
- `pip install -q beautifulsoup4 pypdf python-docx python-pptx openpyxl`
- `pip install -q pydantic`
- `pip install -q fastapi uvicorn typer rich pandas requests lxml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889630f086c832e885cc4b5ccb1b009