### PR TITLE
Add OCR status column in files page

### DIFF
--- a/static/user_files.html
+++ b/static/user_files.html
@@ -50,6 +50,7 @@
                     <th>Size</th>
                     <th id="sortDate" style="cursor:pointer">Updated</th>
                     <th>Status</th>
+                    <th>OCR</th>
                     <th>Actions</th>
                 </tr>
             </thead>
@@ -166,6 +167,7 @@ function render(){
                      `<td>${(f.size/1024).toFixed(1)} KB</td>`+
                      `<td>${new Date(f.uploaded_at).toLocaleString()}</td>`+
                      `<td>${f.status}</td>`+
+                     `<td>${f.ocr_used ? 'Yes' : 'No'}</td>`+
                      `<td><button onclick="del(${f.id})">Delete</button></td>`;
         tbody.appendChild(tr);
     });


### PR DESCRIPTION
## Summary
- show OCR used column in Files list table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68897f75935c832ebfa34faafe7a577e