### PR TITLE
Fix file overwrite warning

### DIFF
--- a/routers/ingest_routes.py
+++ b/routers/ingest_routes.py
@@ -61,7 +61,7 @@ async def upload_files(
             if dest_path.exists() and not replace:
                 raise HTTPException(
                     status_code=409,
-                    detail=f"File '{file.filename}' already exists. Choose replace to overwrite or abort."
+                    detail=f"File '{file.filename}' already exists. Choose <O> for overwrite or <A> for abort."
                 )
 
             if dest_path.exists() and replace:


### PR DESCRIPTION
## Summary
- tweak file conflict message to reference hotkeys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688984521810832eb3404df1b028cbd0