### PR TITLE
Add error logging and admin UI

### DIFF
--- a/DATABASE_LAYOUT.md
+++ b/DATABASE_LAYOUT.md
@@ -6,9 +6,10 @@ and user records.
 
 ## Database
 
-The application logs all chat interactions in a SQLite database at
-`chat_logs.db`. The schema is created in `database.py` and contains a single
-`chat_logs` table:
+The application logs data in a SQLite database at
+`chat_logs.db`. The schema is created in `database.py` and includes tables
+such as `chat_logs`, `llm_logs`, `uploaded_files`, and `error_logs`. The
+`chat_logs` table stores individual chat interactions:
 
 | Column        | Type    | Description                                     |
 |---------------|---------|-------------------------------------------------|
@@ -25,6 +26,9 @@ The application logs all chat interactions in a SQLite database at
 | `tokens_out`  | INTEGER | Number of output tokens                         |
 | `user_feedback` | INTEGER | Optional thumbs up/down feedback              |
 | `user_ip`     | TEXT    | Request IP address for auditing                 |
+
+The `error_logs` table captures server-side errors with columns for timestamp,
+endpoint, tenant, agent, and message.
 
 ## Configuration Files
 

--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -76,3 +76,27 @@ Fields:
 - **description** – Additional context (file name, user question, etc.).
 - **error_message** – Error text if the request failed.
 
+## Table: `error_logs`
+
+The `error_logs` table stores internal application errors and the endpoint where they occurred.
+
+```sql
+CREATE TABLE IF NOT EXISTS error_logs(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts TEXT,
+    endpoint TEXT,
+    tenant TEXT,
+    agent TEXT,
+    message TEXT
+);
+```
+
+Fields:
+
+- **id** – Incrementing identifier.
+- **ts** – Timestamp when the error was logged.
+- **endpoint** – API path that triggered the error.
+- **tenant** – Tenant context if provided.
+- **agent** – Agent name if provided.
+- **message** – Error description.
+

--- a/database.py
+++ b/database.py
@@ -72,6 +72,18 @@ def init_database():
         _ensure_column(con, "llm_logs", "error_message TEXT")
         _ensure_column(con, "uploaded_files", "ocr_used INTEGER DEFAULT 0")
         _ensure_column(con, "uploaded_files", "template INTEGER DEFAULT 0")
+        con.execute(
+            """
+            CREATE TABLE IF NOT EXISTS error_logs(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts TEXT,
+                endpoint TEXT,
+                tenant TEXT,
+                agent TEXT,
+                message TEXT
+            )
+            """
+        )
         con.commit()
 
 
@@ -153,6 +165,42 @@ def log_llm_event(
             )
         )
         con.commit()
+
+
+def log_error(
+    endpoint: str,
+    message: str,
+    *,
+    tenant: str | None = None,
+    agent: str | None = None,
+) -> None:
+    """Log an application error with optional context"""
+    from datetime import datetime, timezone
+
+    with get_db() as con:
+        con.execute(
+            """INSERT INTO error_logs
+               (ts, endpoint, tenant, agent, message)
+               VALUES (?, ?, ?, ?, ?)""",
+            (
+                datetime.now(timezone.utc).isoformat(),
+                endpoint,
+                tenant,
+                agent,
+                message,
+            ),
+        )
+        con.commit()
+
+
+def get_error_logs(limit: int = 100):
+    """Retrieve recent error logs"""
+    with get_db() as con:
+        cur = con.execute(
+            "SELECT ts, endpoint, tenant, agent, message FROM error_logs ORDER BY id DESC LIMIT ?",
+            (limit,),
+        )
+        return cur.fetchall()
 
 
 def record_file_upload(

--- a/main.py
+++ b/main.py
@@ -4,10 +4,11 @@ main.py - FastAPI application entry point
 import logging
 from pathlib import Path
 
-from fastapi import FastAPI, Query
+from fastapi import FastAPI, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import PlainTextResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 # Import routers
 from .routers import (
@@ -21,7 +22,7 @@ from .routers import (
 )
 
 # Import other modules
-from .database import init_database
+from .database import init_database, log_error
 from .widget import generate_widget_js
 from .config import DEFAULT_TENANT, DEFAULT_AGENT
 
@@ -58,6 +59,30 @@ app.include_router(user_routes.router)
 app.include_router(admin_routes.router)
 app.include_router(analytics_routes.router)
 app.include_router(ingest_routes.router)
+
+
+@app.exception_handler(StarletteHTTPException)
+async def http_exception_handler(request: Request, exc: StarletteHTTPException):
+    """Log HTTP errors and return JSON response."""
+    log_error(
+        endpoint=str(request.url.path),
+        tenant=request.query_params.get("tenant"),
+        agent=request.query_params.get("agent"),
+        message=str(exc.detail),
+    )
+    return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+
+
+@app.exception_handler(Exception)
+async def general_exception_handler(request: Request, exc: Exception):
+    """Catch-all handler for unexpected errors."""
+    log_error(
+        endpoint=str(request.url.path),
+        tenant=request.query_params.get("tenant"),
+        agent=request.query_params.get("agent"),
+        message=str(exc),
+    )
+    return JSONResponse(status_code=500, content={"detail": "Internal Server Error"})
 
 # Widget endpoint
 @app.get("/widget.js", response_class=PlainTextResponse)

--- a/routers/admin_routes.py
+++ b/routers/admin_routes.py
@@ -192,6 +192,25 @@ async def get_llm_logs(limit: int = 100):
     return {"logs": logs}
 
 
+@router.get("/error_logs")
+async def get_error_logs(limit: int = 100):
+    """Retrieve recent application error logs"""
+    from ..database import get_error_logs as db_get_error_logs
+
+    rows = db_get_error_logs(limit)
+    logs = [
+        {
+            "ts": ts,
+            "endpoint": endpoint,
+            "tenant": tenant,
+            "agent": agent,
+            "message": message,
+        }
+        for ts, endpoint, tenant, agent, message in rows
+    ]
+    return {"logs": logs}
+
+
 @router.get("/llm_models")
 async def get_llm_models(provider: str = "anthropic"):
     """Return available models for a given LLM provider."""

--- a/routers/ingest_routes.py
+++ b/routers/ingest_routes.py
@@ -78,7 +78,7 @@ async def upload_files(
             fid = record_file_upload(tenant, agent, file.filename, dest_path.stat().st_size)
             file_ids.append(fid)
             file_map[file.filename] = fid
-        
+
         # Ingest the files
         ocr_flags = ingest(tenant, agent, files=temp_files)
 
@@ -94,14 +94,14 @@ async def upload_files(
             "message": f"Successfully uploaded and processed {len(files)} files",
             "files": [f.filename for f in files]
         }
-        
+
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(
             status_code=500,
             detail=f"Error processing files: {str(e)}"
         )
-    finally:
-        pass
 
 
 @router.post("/ingest/sitemap")

--- a/static/admin.html
+++ b/static/admin.html
@@ -622,8 +622,8 @@
                     <div id="llmLogs" class="hidden"></div>
                 </div>
                 <div class="form-group">
-                    <button id="chatLogsBtn" class="btn">Show Chat Logs</button>
-                    <div id="chatLogs" class="hidden"></div>
+                    <button id="errorLogsBtn" class="btn">Show Error Log</button>
+                    <div id="errorLogs" class="hidden"></div>
                 </div>
                 <div class="form-group">
                     <label for="userTimeout">User Timeout (minutes)</label>
@@ -1099,7 +1099,7 @@
             });
             document.getElementById('llmTestBtn').addEventListener('click', runLlmTest);
             document.getElementById('llmLogsBtn').addEventListener('click', loadLlmLogs);
-            document.getElementById('chatLogsBtn').addEventListener('click', loadChatLogs);
+            document.getElementById('errorLogsBtn').addEventListener('click', loadErrorLogs);
 
             // Forms
             document.getElementById('createTenantForm').addEventListener('submit', handleCreateTenant);
@@ -1600,17 +1600,17 @@
             `;
         }
 
-        async function loadChatLogs() {
-            const container = document.getElementById('chatLogs');
+        async function loadErrorLogs() {
+            const container = document.getElementById('errorLogs');
             container.classList.remove('hidden');
             container.innerHTML = 'Loading...';
             try {
-                const response = await fetch(`${API_BASE}/chat/history?limit=25`, {
+                const response = await fetch(`${API_BASE}/error_logs?limit=25`, {
                     headers: { 'Authorization': `Bearer ${authToken}` }
                 });
                 if (response.ok) {
                     const data = await response.json();
-                    container.innerHTML = formatChatLogs(data);
+                    container.innerHTML = formatErrorLogs(data.logs || []);
                 } else {
                     container.innerHTML = 'Failed to load logs';
                 }
@@ -1620,15 +1620,17 @@
             }
         }
 
-        function formatChatLogs(logs) {
+        function formatErrorLogs(logs) {
             if (!logs.length) {
                 return '<p>No logs found.</p>';
             }
             const rows = logs.map(log => `
                 <tr>
-                    <td>${new Date(log.timestamp).toLocaleString()}</td>
-                    <td>${log.question}</td>
-                    <td>${log.answer}</td>
+                    <td>${new Date(log.ts).toLocaleString()}</td>
+                    <td>${log.endpoint}</td>
+                    <td>${log.tenant || ''}</td>
+                    <td>${log.agent || ''}</td>
+                    <td>${log.message}</td>
                 </tr>
             `).join('');
             return `
@@ -1637,8 +1639,10 @@
                         <thead>
                             <tr>
                                 <th>Timestamp</th>
-                                <th>Question</th>
-                                <th>Answer</th>
+                                <th>Endpoint</th>
+                                <th>Tenant</th>
+                                <th>Agent</th>
+                                <th>Error</th>
                             </tr>
                         </thead>
                         <tbody>${rows}</tbody>


### PR DESCRIPTION
## Summary
- log application errors in new `error_logs` table
- expose an `/error_logs` endpoint and admin page viewer
- improve upload error handling and central exception logging

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688eaf6b8b98832ea5bd8a9b2e32dcce