### PR TITLE
fix: load footer logo from admin settings

### DIFF
--- a/static/user.html
+++ b/static/user.html
@@ -690,7 +690,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 </script>
 <footer>
-    <img id="footerLogo" src="https://www.craftedquery.com/logo.svg" alt="Crafted Query Logo"> 2025 © Crafted Query. All rights reserved. -
+    <img id="footerLogo" alt="Crafted Query Logo"> 2025 © Crafted Query. All rights reserved. -
     <a id="footerLink1" href="https://www.craftedquery.com/about">About us</a> -
     <a id="footerLink2" href="https://www.craftedquery.com/contact">Contact us</a> -
     <a id="footerLink3" href="https://www.craftedquery.com/status">Status</a>.

--- a/static/user_files.html
+++ b/static/user_files.html
@@ -102,7 +102,7 @@ function applyCustomStyles(){
         }
     });
 }
-applyCustomStyles();
+document.addEventListener("DOMContentLoaded", applyCustomStyles);
 const params = new URLSearchParams(window.location.search);
 const tenant = params.get('tenant');
 const agent = params.get('agent');
@@ -196,7 +196,7 @@ document.getElementById('sortName').addEventListener('click',()=>{sortField='nam
 document.getElementById('sortDate').addEventListener('click',()=>{sortField='date';sortAsc=!sortAsc;render();});
 </script>
 <footer>
-    <img id="footerLogo" src="https://www.craftedquery.com/logo.svg" alt="Crafted Query Logo"> 2025 © Crafted Query. All rights reserved. -
+    <img id="footerLogo" alt="Crafted Query Logo"> 2025 © Crafted Query. All rights reserved. -
     <a id="footerLink1" href="https://www.craftedquery.com/about">About us</a> -
     <a id="footerLink2" href="https://www.craftedquery.com/contact">Contact us</a> -
     <a id="footerLink3" href="https://www.craftedquery.com/status">Status</a>.

--- a/static/user_upload.html
+++ b/static/user_upload.html
@@ -116,7 +116,7 @@ function applyCustomStyles(){
         }
     });
 }
-applyCustomStyles();
+document.addEventListener("DOMContentLoaded", applyCustomStyles);
 const params = new URLSearchParams(window.location.search);
 const tenant = params.get('tenant');
 const agent = params.get('agent');
@@ -203,7 +203,7 @@ async function uploadFiles(files, replace=false){
 }
 </script>
 <footer>
-    <img id="footerLogo" src="https://www.craftedquery.com/logo.svg" alt="Crafted Query Logo"> 2025 © Crafted Query. All rights reserved. -
+    <img id="footerLogo" alt="Crafted Query Logo"> 2025 © Crafted Query. All rights reserved. -
     <a id="footerLink1" href="https://www.craftedquery.com/about">About us</a> -
     <a id="footerLink2" href="https://www.craftedquery.com/contact">Contact us</a> -
     <a id="footerLink3" href="https://www.craftedquery.com/status">Status</a>.


### PR DESCRIPTION
## Summary
- Remove hardcoded footer logo from user pages
- Initialize custom styles on DOMContentLoaded so logoUrl from admin settings populates footer

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689658c73be4832ea2611cab38115c9d