### PR TITLE
Add tenant dropdown and conditional new tenant creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,9 @@ __pycache__/
 venv/
 *.pyc
 
+# Node.js dependencies
+node_modules/
+package-lock.json
+
 .env
 static/gavel-2-64.ico

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "cg_bot",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node --test static/admin.test.js"
+  },
+  "devDependencies": {
+    "jsdom": "^26.1.0"
+  }
+}

--- a/static/admin.html
+++ b/static/admin.html
@@ -716,7 +716,11 @@
             <form id="createTenantForm">
                 <div class="form-group">
                     <label for="tenantName">Tenant Name</label>
-                    <input type="text" id="tenantName" name="tenantName" required>
+                    <select id="tenantName" name="tenantName" required></select>
+                </div>
+                <div id="newTenantNameGroup" class="form-group hidden">
+                    <label for="newTenantName">New Tenant Name</label>
+                    <input type="text" id="newTenantName" name="newTenantName">
                 </div>
                 <div class="form-group">
                     <label for="agentName">Initial Agent Name</label>
@@ -1091,7 +1095,10 @@
             });
             
             // Create buttons
-            document.getElementById('createTenantBtn').addEventListener('click', () => showModal('createTenantModal'));
+            document.getElementById('createTenantBtn').addEventListener('click', () => {
+                document.getElementById('createTenantForm').reset();
+                loadTenantsForCreation();
+            });
             document.getElementById('createUserBtn').addEventListener('click', () => {
                 document.getElementById('createUserForm').reset();
                 loadTenantsForUser();
@@ -1697,10 +1704,14 @@
         // Tenant management
         async function handleCreateTenant(e) {
             e.preventDefault();
-            
+
             const formData = new FormData(e.target);
-            const tenantName = formData.get('tenantName');
+            let tenantName = formData.get('tenantName');
             const agentName = formData.get('agentName');
+
+            if (tenantName === '__new__') {
+                tenantName = formData.get('newTenantName');
+            }
 
             try {
                 // Create tenant directory and agent config via API
@@ -1856,6 +1867,58 @@
         }
 
         // User management
+        async function loadTenantsForCreation() {
+            const select = document.getElementById('tenantName');
+            const newTenantGroup = document.getElementById('newTenantNameGroup');
+            const newTenantInput = document.getElementById('newTenantName');
+
+            if (!select) return;
+
+            select.innerHTML = '';
+            newTenantGroup.classList.add('hidden');
+            newTenantInput.required = false;
+
+            try {
+                const response = await fetch(`${API_BASE}/tenants`, {
+                    headers: { 'Authorization': `Bearer ${authToken}` }
+                });
+
+                if (response.ok) {
+                    const tenants = await response.json();
+                    tenants.forEach(t => {
+                        const option = document.createElement('option');
+                        option.value = t.tenant;
+                        option.textContent = t.tenant;
+                        select.appendChild(option);
+                    });
+                }
+            } catch (error) {
+                console.error('Failed to load tenants for creation:', error);
+            }
+
+            if (currentUser && currentUser.tenant === '*') {
+                const option = document.createElement('option');
+                option.value = '__new__';
+                option.textContent = 'Create New Tenant';
+                select.appendChild(option);
+            }
+
+            select.onchange = function() {
+                if (this.value === '__new__') {
+                    newTenantGroup.classList.remove('hidden');
+                    newTenantInput.required = true;
+                } else {
+                    newTenantGroup.classList.add('hidden');
+                    newTenantInput.required = false;
+                }
+            };
+
+            // Trigger change handler for initial state
+            select.dispatchEvent(new Event('change'));
+
+            showModal('createTenantModal');
+        }
+
         async function loadTenantsForUser() {
             try {
                 const response = await fetch(`${API_BASE}/tenants`, {

--- a/static/admin.test.js
+++ b/static/admin.test.js
@@ -1,0 +1,82 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('node:vm');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { JSDOM } = require('jsdom');
+
+const htmlPath = path.join(__dirname, 'admin.html');
+const html = fs.readFileSync(htmlPath, 'utf8');
+const scriptContent = html.match(/<script>([\s\S]*)<\/script>/)[1];
+
+function setupDom() {
+  const dom = new JSDOM(
+    `<select id="tenantName"></select>
+<div id="newTenantNameGroup" class="hidden"><input id="newTenantName" /></div>
+<div id="createTenantModal" class="hidden"></div>`,
+    { url: 'http://localhost', runScripts: 'dangerously' }
+  );
+
+  // Ignore DOMContentLoaded handlers to prevent unrelated errors
+  const originalAddEventListener = dom.window.document.addEventListener.bind(dom.window.document);
+  dom.window.document.addEventListener = (type, listener, options) => {
+    if (type !== 'DOMContentLoaded') {
+      originalAddEventListener(type, listener, options);
+    }
+  };
+
+  dom.window.fetch = async () => ({
+    ok: true,
+    json: async () => [{ tenant: 'TenantA' }, { tenant: 'TenantB' }]
+  });
+
+  const scriptEl = dom.window.document.createElement('script');
+  scriptEl.textContent = scriptContent;
+  dom.window.document.body.appendChild(scriptEl);
+
+  return dom;
+}
+
+test('limited access user sees only allowed tenants', async () => {
+  const dom = setupDom();
+  const vmCtx = dom.getInternalVMContext();
+  vm.runInContext('currentUser = { tenant: "TenantA", role: "user" };', vmCtx);
+
+  await dom.window.loadTenantsForCreation();
+
+  const select = dom.window.document.getElementById('tenantName');
+  const options = Array.from(select.options).map(o => o.value);
+  assert.deepStrictEqual(options, ['TenantA', 'TenantB']);
+
+  const group = dom.window.document.getElementById('newTenantNameGroup');
+  const input = dom.window.document.getElementById('newTenantName');
+  assert(group.classList.contains('hidden'));
+  assert.equal(input.required, false);
+});
+
+test('all access user can create new tenant and toggles new tenant input', async () => {
+  const dom = setupDom();
+  const vmCtx = dom.getInternalVMContext();
+  vm.runInContext('currentUser = { tenant: "*", role: "system_admin" };', vmCtx);
+
+  await dom.window.loadTenantsForCreation();
+
+  const select = dom.window.document.getElementById('tenantName');
+  const options = Array.from(select.options).map(o => o.value);
+  assert.deepStrictEqual(options, ['TenantA', 'TenantB', '__new__']);
+
+  const group = dom.window.document.getElementById('newTenantNameGroup');
+  const input = dom.window.document.getElementById('newTenantName');
+  assert(group.classList.contains('hidden'));
+  assert.equal(input.required, false);
+
+  select.value = '__new__';
+  select.dispatchEvent(new dom.window.Event('change'));
+  assert(!group.classList.contains('hidden'));
+  assert.equal(input.required, true);
+
+  select.value = 'TenantA';
+  select.dispatchEvent(new dom.window.Event('change'));
+  assert(group.classList.contains('hidden'));
+  assert.equal(input.required, false);
+});


### PR DESCRIPTION
## Summary
- Replace tenant name text input with dropdown in Create Tenant modal
- Populate dropdown with allowed tenants and expose "Create New Tenant" option for users with access to all tenants
- Handle new tenant selection when submitting tenant creation form
- Add front-end tests for tenant dropdown behavior and ignore Node.js artifacts

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68967aca2848832ebb64368d9299f94a