### PR TITLE
Refresh chat sidebar from LLM logs

### DIFF
--- a/static/chat.html
+++ b/static/chat.html
@@ -328,9 +328,22 @@ function addMessage(text,cls,sources=[]){
 }
 
 async function loadHistory(){
-    const res=await fetch(`/history?tenant=${tenant}&agent=${agent}&limit=25`,{headers:{Authorization:`Bearer ${token}`}});
+    const res=await fetch(`/llm_logs?limit=25`,{headers:{Authorization:`Bearer ${token}`}});
     if(res.ok){
-        chatHistory=await res.json();
+        const data=await res.json();
+        chatHistory=(data.logs||[])
+            // `llm_logs` is a shared table across tenants and agents, so we filter
+            // by the active tenant/agent to avoid cross-tenant bleed. The table also
+            // stores non-question events, but `llm.py` records user prompts as
+            // `user:{user} q:{question}`. We keep only entries whose descriptions
+            // include `q:` and split on it to recover the question. If this format
+            // changes—or a question itself contains `q:`—the history parsing may
+            // need adjustment.
+            .filter(l=>l.tenant===tenant&&l.agent===agent&&l.description&&l.description.includes('q:'))
+            .map(l=>{
+                const q=l.description.split('q:')[1]||'';
+                return{timestamp:l.ts,question:q.trim()};
+            });
         filteredHistory=chatHistory;
         renderHistory();
     }
@@ -346,6 +359,7 @@ async function sendMessage(msg){
     if(res.ok){
         const data=await res.json();
         addMessage(data.reply,'bot',data.sources||[]);
+        await loadHistory();
     }else{
         addMessage('Error: '+res.status,'bot');
     }


### PR DESCRIPTION
## Summary
- Pull chat history from `/llm_logs` and filter for current tenant/agent
- Reload sidebar history after each new message
- Clarify why history filtering checks tenant, agent and `q:` marker

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896b4426580832ebe84efe6ae5e902d