### PR TITLE
feat: extend styling panel controls

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -662,6 +662,52 @@
                 </div>
                 <div class="form-row">
                     <div class="form-group">
+                        <label for="gray-100">Gray 100</label>
+                        <input type="color" id="gray-100">
+                    </div>
+                    <div class="form-group">
+                        <label for="gray-200">Gray 200</label>
+                        <input type="color" id="gray-200">
+                    </div>
+                </div>
+                <div class="form-row">
+                    <div class="form-group">
+                        <label for="gray-300">Gray 300</label>
+                        <input type="color" id="gray-300">
+                    </div>
+                    <div class="form-group">
+                        <label for="gray-600">Gray 600</label>
+                        <input type="color" id="gray-600">
+                    </div>
+                </div>
+                <div class="form-row">
+                    <div class="form-group">
+                        <label for="gray-800">Gray 800</label>
+                        <input type="color" id="gray-800">
+                    </div>
+                    <div class="form-group">
+                        <label for="black">Black</label>
+                        <input type="color" id="black">
+                    </div>
+                </div>
+                <div class="form-row">
+                    <div class="form-group">
+                        <label for="white">White</label>
+                        <input type="color" id="white">
+                    </div>
+                    <div class="form-group">
+                        <label for="shadow">Shadow</label>
+                        <input type="text" id="shadow">
+                    </div>
+                </div>
+                <div class="form-row">
+                    <div class="form-group">
+                        <label for="shadowLg">Shadow Large</label>
+                        <input type="text" id="shadowLg">
+                    </div>
+                </div>
+                <div class="form-row">
+                    <div class="form-group">
                         <label for="headerBg">Header Background</label>
                         <input type="color" id="headerBg">
                     </div>
@@ -1043,10 +1089,19 @@
             secondary: "#2f2f2f",
             danger: "#f44336",
             warning: "#ff9800",
+            "gray-100": "#f5f5f5",
+            "gray-200": "#e0e0e0",
+            "gray-300": "#bdbdbd",
+            "gray-600": "#757575",
+            "gray-800": "#424242",
+            black: "#000000",
+            white: "#ffffff",
             headerBg: "#d71920",
             headerText: "#ffffff",
             btnRadius: 4,
             footerBg: "#2f2f2f",
+            shadow: "0 2px 4px rgba(0,0,0,0.1)",
+            shadowLg: "0 4px 12px rgba(0,0,0,0.15)",
             bodyFontSize: 16,
             logoUrl: "https://www.craftedquery.com/logo.svg",
             footerLink1Text: "About us",
@@ -1171,7 +1226,7 @@
             });
 
             // Styling inputs
-            ["primary","primaryDark","secondary","danger","warning","headerBg","headerText","btnRadius","footerBg","bodyFontSize","logoUrl","footerLink1Text","footerLink1Url","footerLink2Text","footerLink2Url","footerLink3Text","footerLink3Url"].forEach(id => {
+            ["primary","primaryDark","secondary","danger","warning","gray-100","gray-200","gray-300","gray-600","gray-800","black","white","headerBg","headerText","btnRadius","footerBg","shadow","shadowLg","bodyFontSize","logoUrl","footerLink1Text","footerLink1Url","footerLink2Text","footerLink2Url","footerLink3Text","footerLink3Url"].forEach(id => {
                 const el = document.getElementById(id);
                 if (el) {
                     el.addEventListener("change", () => {


### PR DESCRIPTION
## Summary
- add gray palette, base color, and shadow inputs to styling panel
- expand default style config and listener set to persist new options

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897c9a1b4e8832ea286b7062abb4469